### PR TITLE
fix: サイドバー内スクロール時の背景スクロール問題を修正

### DIFF
--- a/apps/web/src/features/sheet/components/BookDetailSidebar.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailSidebar.tsx
@@ -37,6 +37,28 @@ export const BookDetailSidebar: React.FC<Props> = ({
     setCurrentBook(book)
   }, [book])
 
+  // サイドバーが開いている時に背景のスクロールを防ぐ
+  useEffect(() => {
+    if (open) {
+      // 現在のスクロール位置を保存
+      const scrollY = window.scrollY
+      // bodyのスタイルを設定してスクロールを防ぐ
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${scrollY}px`
+      document.body.style.width = '100%'
+
+      return () => {
+        // コンポーネントが閉じられたらスタイルをリセット
+        const scrollY = document.body.style.top
+        document.body.style.position = ''
+        document.body.style.top = ''
+        document.body.style.width = ''
+        // 元のスクロール位置に戻す
+        window.scrollTo(0, parseInt(scrollY || '0') * -1)
+      }
+    }
+  }, [open])
+
   const onClickEdit = async () => {
     const isDiff = Object.keys(book).some((key) => book[key] !== newBook[key])
     if (isDiff) {


### PR DESCRIPTION
## 概要
本の詳細サイドバーが開いている時、サイドバー内でスクロールすると背景の画面も一緒にスクロールされてしまう問題を修正しました。

## 変更内容
- `BookDetailSidebar` コンポーネントに `useEffect` フックを追加
- サイドバーが開いた時に `document.body` に `position: fixed` を適用して背景のスクロールを防ぐ
- 現在のスクロール位置を保存し、サイドバーを閉じた時に元の位置に復元
- サイドバー内のコンテンツは独立してスクロール可能

## テスト
- [x] サイドバーを開いた状態でサイドバー内をスクロール → 背景がスクロールされないことを確認
- [x] サイドバーを閉じた時に元のスクロール位置に戻ることを確認
- [x] サイドバー内のコンテンツが正常にスクロールできることを確認

## 関連Issue
なし