### PR TITLE
AI分析モーダルの横幅を拡大

### DIFF
--- a/apps/web/src/features/sheet/components/AiSummaries/Confirm.tsx
+++ b/apps/web/src/features/sheet/components/AiSummaries/Confirm.tsx
@@ -105,8 +105,8 @@ export const Confirm: React.FC<Props> = ({
 
   const isLimited = data?.count >= MONTHLY_LIMIT
   return (
-    <Modal open={open} onClose={onCancel}>
-      <div className="w-full rounded-md p-6 sm:w-[480px] sm:p-10">
+    <Modal open={open} onClose={onCancel} className="w-full sm:w-[480px]">
+      <div className="w-full rounded-md p-6 sm:p-10">
         <div className="mb-2 text-center text-sm font-bold leading-5">
           今月の残り：
           <span className="fon-bold mx-1">


### PR DESCRIPTION
スマホでの表示時に、AI分析モーダルの横幅を450pxから480pxに変更。
これにより、書籍詳細モーダルと同じ幅になり、より広い表示領域を確保。