### PR TITLE
feat: 連続書籍登録フローを追加

### DIFF
--- a/apps/web/src/components/input/SearchBox/AddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/AddModal.tsx
@@ -18,9 +18,9 @@ import { SheetAddModal } from '@/features/sheet/components/SheetAddModal'
 import { AiOutlineFileAdd } from 'react-icons/ai'
 import { useSession } from 'next-auth/react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useAtom, useAtomValue } from 'jotai'
-import { openAddModalAtom } from '@/store/modal/atom'
-import { addBookAtom } from '@/store/book/atom'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { openAddModalAtom, openSearchModalAtom } from '@/store/modal/atom'
+import { addBookAtom, registeredBookCountAtom } from '@/store/book/atom'
 import { Label } from '../Label'
 import { MaskingHint } from '@/components/label/MaskingHint'
 
@@ -55,6 +55,8 @@ export const AddModal: React.FC = () => {
   const [open, setOpen] = useAtom(openAddModalAtom)
   const item = useAtomValue(addBookAtom)
   const { data: session } = useSession()
+  const setOpenSearchModal = useSetAtom(openSearchModalAtom)
+  const [registeredCount, setRegisteredCount] = useAtom(registeredBookCountAtom)
   const apolloClient = useApolloClient()
   const { data: sheetsData, refetch: refetchSheets } = useQuery(
     getSheetsQuery,
@@ -129,6 +131,7 @@ export const AddModal: React.FC = () => {
     setResponse(res)
     if (res.result) {
       apolloClient.refetchQueries({ include: ['GetBooks'] })
+      setRegisteredCount((c) => c + 1)
       reward()
     }
     setLoading(false)
@@ -318,7 +321,7 @@ export const AddModal: React.FC = () => {
                     {response.result ? (
                       <SuccessAlert
                         open={!!response}
-                        text={`『${response.bookTitle}』を「${response.sheetName}」に追加しました`}
+                        text={`『${response.bookTitle}』を「${response.sheetName}」に追加しました${registeredCount > 1 ? `（今回${registeredCount}冊目）` : ''}`}
                         onClose={() => {
                           setResponse(null)
                         }}
@@ -335,17 +338,28 @@ export const AddModal: React.FC = () => {
                   </div>
                 )}
                 {response?.bookId > 0 ? (
-                  <button
-                    className="flex h-12 w-full items-center justify-center rounded-b-md bg-green-600 px-4 py-1 font-bold text-white hover:bg-green-700 disabled:bg-blue-700"
-                    onClick={() => {
-                      setOpen(false)
-                      router.push(
-                        `/${session.user.name}/sheets/${response.sheetName}`
-                      )
-                    }}
-                  >
-                    <span id="rewardId">シートに飛ぶ</span>
-                  </button>
+                  <div className="flex w-full">
+                    <button
+                      className="flex h-12 flex-1 items-center justify-center rounded-bl-md bg-blue-600 px-4 py-1 font-bold text-white hover:bg-blue-700"
+                      onClick={() => {
+                        setOpen(false)
+                        setOpenSearchModal(true)
+                      }}
+                    >
+                      <span id="rewardId">続けて登録</span>
+                    </button>
+                    <button
+                      className="flex h-12 flex-1 items-center justify-center rounded-br-md bg-green-600 px-4 py-1 font-bold text-white hover:bg-green-700"
+                      onClick={() => {
+                        setOpen(false)
+                        router.push(
+                          `/${session.user.name}/sheets/${response.sheetName}`
+                        )
+                      }}
+                    >
+                      シートに飛ぶ
+                    </button>
+                  </div>
                 ) : (
                   <button
                     className="flex h-12 w-full items-center justify-center rounded-b-md bg-blue-600 px-4 py-1 font-bold text-white hover:bg-blue-700 disabled:bg-gray-500"

--- a/apps/web/src/components/input/SearchBox/SearchModal.tsx
+++ b/apps/web/src/components/input/SearchBox/SearchModal.tsx
@@ -5,7 +5,8 @@ import { Books } from './Books'
 import { UserBooks } from './UserBooks'
 import { BarcodeScan } from './BarcodeScan'
 import { openSearchModalAtom } from '@/store/modal/atom'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
+import { registeredBookCountAtom } from '@/store/book/atom'
 import { Template } from './Template'
 import { ISBNSearchResult } from './ISBNSearchResult'
 
@@ -26,6 +27,7 @@ const isISBNLike = (input: string): boolean => {
 
 export const SearchModal: React.FC = () => {
   const [open, setOpen] = useAtom(openSearchModalAtom)
+  const registeredCount = useAtomValue(registeredBookCountAtom)
   const ref = useRef<HTMLInputElement>(null)
   const [showCamera, setShowCamera] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -56,6 +58,16 @@ export const SearchModal: React.FC = () => {
       onClose={onClose}
       className="h-3/4 w-full overflow-auto sm:w-3/4 lg:w-1/2"
     >
+      {/* 登録冊数バッジ */}
+      {registeredCount > 0 && (
+        <div className="flex items-center gap-2 border-b border-b-[#f1f5f9] bg-blue-50 px-4 py-2">
+          <span className="flex h-6 min-w-[24px] items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-bold text-white">
+            {registeredCount}
+          </span>
+          <span className="text-sm text-blue-700">冊登録済み</span>
+        </div>
+      )}
+
       {/* 検索入力 + カメラボタン */}
       <div className="flex shrink-0 items-center border-b border-b-[#f1f5f9] px-2 pt-2">
         <div className="relative w-full text-gray-600">

--- a/apps/web/src/store/book/atom.ts
+++ b/apps/web/src/store/book/atom.ts
@@ -2,3 +2,6 @@ import { SearchResult } from '@/types/search'
 import { atom } from 'jotai'
 
 export const addBookAtom = atom(null as unknown as SearchResult)
+
+/** セッション中に登録した本の冊数 */
+export const registeredBookCountAtom = atom<number>(0)


### PR DESCRIPTION
登録成功後に「続けて登録」ボタンを表示し、検索モーダルに即座に
戻れるようにした。セッション中の登録冊数をバッジで表示し、
達成感を演出。複数冊まとめて登録する際のUXを大幅に改善。

- AddModal: 成功時に「続けて登録」「シートに飛ぶ」の2ボタン表示
- SearchModal: セッション中の登録冊数バッジを表示
- registeredBookCountAtom: セッション中の登録冊数を管理するatom追加
- 成功メッセージに累計冊数を表示（2冊目以降）

https://claude.ai/code/session_018CnsT5btGA2pNK4EuhP2Pi