### PR TITLE
Migrate from MariaDB to MySQL with docker compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ pnpm --filter web lighthouse
 ### MeiliSearch
 
 - 日本語プロトタイプビルド使用のため、通常版との互換性なし
-- インデックスリセット時は`docker-compose restart meilisearch`
+- インデックスリセット時は`docker compose restart meilisearch`
 
 ### デプロイ（GitHub Actions）
 
@@ -464,7 +464,7 @@ git commit -m "feat: 機能の説明"
 |---|---|---|
 | `ECONNREFUSED :3000` | Webサーバー停止 | `bash scripts/auto-fix.sh web` |
 | `ECONNREFUSED :4000` | APIサーバー停止 | `bash scripts/auto-fix.sh api` |
-| `Can't reach database server` | MariaDBコンテナ停止 | `bash scripts/auto-fix.sh db` |
+| `Can't reach database server` | MySQLコンテナ停止 | `bash scripts/auto-fix.sh db` |
 | `Table 'kidoku.xxx' doesn't exist` | db:push 漏れ | `pnpm --filter web db:push && pnpm --filter api db:push` |
 | `Unknown type "XxxInput"` | codegen 漏れ | `pnpm --filter web codegen` |
 | `Cannot find module '@prisma/client'` | prisma generate 漏れ | `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter web prisma generate && PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter api prisma generate` |
@@ -496,9 +496,9 @@ pnpm --filter api prisma generate
 
 ```bash
 # 全コンテナ再起動
-docker-compose down && docker-compose up -d
+docker compose down && docker compose up -d
 
 # MeiliSearchデータリセット
 rm -rf docker/meilisearch/data/meilisearch
-docker-compose up -d meilisearch
+docker compose up -d meilisearch
 ```

--- a/docs/SANDBOX_SETUP.md
+++ b/docs/SANDBOX_SETUP.md
@@ -1,8 +1,8 @@
 # サンドボックス環境セットアップ手順
 
-[Claude Code on the Web](https://code.claude.com/docs/ja/claude-code-on-the-web) のクラウドサンドボックス環境で Docker コンテナを立ち上げ、DB テーブルを作成するまでの手順書。
+[Claude Code on the Web](https://code.claude.com/docs/ja/claude-code-on-the-web) のクラウドサンドボックス環境で docker compose を使ってコンテナを起動し、DB テーブルを作成するまでの手順書。
 
-> **注意**: この手順は Claude Code on the Web（クラウドVM）専用です。ローカル開発では docker-compose を使ってください。
+> **注意**: この手順は Claude Code on the Web（クラウドVM）専用です。ローカル開発でも同じ docker-compose.yml を使用できます。
 
 ## 自動セットアップ（推奨）
 
@@ -26,6 +26,7 @@ SANDBOX=1 bash scripts/sandbox-setup.sh
 | `scripts/sandbox-setup.sh` | 環境の一括セットアップ（Docker・DB・シード・サーバー起動） |
 | `scripts/dev-server.sh start\|stop\|restart\|status\|logs` | 開発サーバーの管理 |
 | `scripts/health-check.sh` | 全コンポーネントのヘルスチェック |
+| `scripts/auto-fix.sh` | 個別コンポーネントの自動診断・修復 |
 | `scripts/ui-check.sh [パス...]` | 指定ページのスクリーンショット撮影（裏口ログイン付き） |
 
 ### AI Agent 自律開発の仕組み
@@ -47,9 +48,8 @@ SANDBOX=1 bash scripts/sandbox-setup.sh
 
 ## 前提
 
-- Docker コマンドはプリインストール済み（Docker 29.2.1）
-- カーネルが古い（Linux 4.4.0）ため `nftables` 非対応
-- ネットワークは egress プロキシ経由（ホワイトリスト方式）
+- Docker コマンドはプリインストール済み（Docker 29.2.1 + Compose v5）
+- ネットワークはエグレスプロキシ経由（Docker デーモンにプロキシ設定が必要）
 
 ## 手順
 
@@ -65,78 +65,79 @@ pnpm install
 cp .env.example .env
 ```
 
-`.env` の DB 関連を以下のように変更する（サンドボックスではホストネットワーク上の `3306` を使用）:
+`.env` の内容（docker-compose.yml が参照する変数）:
 
 ```
-DB_HOST=localhost
-DB_PORT=3306
+MEILI_MASTER_KEY=YourMasterKey
+MEILI_HTTP_ADDR=0.0.0.0:7700
+DB_HOST=db
+DB_PORT=13306
 DB_USER=dev
 DB_PASS=pass
 DB_NAME=kidoku
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku"
 ```
 
-### 3. iptables を legacy に切り替え
+### 3. Docker デーモン起動（プロキシ設定付き）
 
-nftables がカーネル非対応のため:
-
-```bash
-sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
-sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-```
-
-### 4. Docker デーモンを起動
+サンドボックス環境では外部通信がエグレスプロキシ経由に制限されています。
+Docker デーモンがイメージを pull するには、`daemon.json` にプロキシを設定する必要があります。
 
 ```bash
-sudo -E dockerd --iptables=false --bridge=none --storage-driver=vfs &>/tmp/dockerd.log &
+# daemon.json にプロキシ設定を書き込む
+sudo mkdir -p /etc/docker
+cat <<EOF | sudo tee /etc/docker/daemon.json
+{
+  "proxies": {
+    "http-proxy": "${HTTP_PROXY}",
+    "https-proxy": "${HTTPS_PROXY}",
+    "no-proxy": "localhost,127.0.0.1"
+  },
+  "dns": ["8.8.8.8", "8.8.4.4"]
+}
+EOF
+
+# Docker デーモン起動
+sudo -E dockerd &>/tmp/kidoku/dockerd.log &
 sleep 5
 docker info  # 起動確認
 ```
 
-### 5. DB コンテナ起動（MariaDB）
+> **ポイント**: `--iptables=false` や `--bridge=none` は不要です。プロキシ設定さえあれば通常モードで起動できます。
 
-MySQL イメージは pull 不可のため MariaDB で代替する。`--network=host` 必須。
+### 4. docker compose でコンテナ起動
 
 ```bash
-docker run -d --name kidoku_db --network=host \
-  -e MARIADB_ROOT_PASSWORD=pass \
-  -e MARIADB_DATABASE=kidoku \
-  -e MARIADB_USER=dev \
-  -e MARIADB_PASSWORD=pass \
-  mariadb:lts
+docker compose up -d
 ```
 
-### 6. MeiliSearch コンテナ起動
+MySQL 9.3 と MeiliSearch（日本語版）が起動します。
+
+### 5. コンテナ起動確認
 
 ```bash
-docker run -d --name kidoku_meilisearch --network=host \
-  -e MEILI_HTTP_ADDR=0.0.0.0:7700 \
-  -e MEILI_MASTER_KEY=YourMasterKey \
-  getmeili/meilisearch:prototype-japanese-6
+docker compose ps
 ```
 
-### 7. コンテナ起動確認
+`kidoku_db` と `kidoku-meilisearch-1` が `Up` になっていることを確認。
+
+> **MeiliSearch のバージョン不一致エラー**: `failed to infer the version of the database` が出た場合は、データディレクトリをクリアして再起動:
+> ```bash
+> docker compose rm -f meilisearch
+> rm -rf docker/meilisearch/data/meilisearch
+> docker compose up -d meilisearch
+> ```
+
+### 6. DB テーブル作成（Prisma db push）
 
 ```bash
-sleep 15 && docker ps
-```
-
-MariaDB と MeiliSearch の両方が `Up` になっていることを確認。
-
-### 8. DB テーブル作成（Prisma db push）
-
-Prisma スキーマを DB に反映してテーブルを作成する。
-`DATABASE_URL` に Accelerate URL が設定されている場合は、環境変数で直接接続先を上書きする。
-
-```bash
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" \
+DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" \
   npx prisma db push --schema=apps/web/prisma/schema.prisma
 ```
 
-### 9. テーブル作成確認
+### 7. テーブル作成確認
 
 ```bash
-docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SHOW TABLES;"
+docker exec kidoku_db mysql -u dev -ppass kidoku -e "SHOW TABLES;"
 ```
 
 以下のテーブルが作成されていれば成功:
@@ -153,16 +154,16 @@ docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SHOW TABLES;"
 | verificationtokens |
 | yearly_top_books |
 
-### 10. シードデータ投入（オプション）
+### 8. シードデータ投入（オプション）
 
 開発用のサンプルデータを投入する。テストユーザー・本棚・書籍（19冊）・年間ベスト・AI要約・テンプレートが作成される。
 
 ```bash
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" \
+DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" \
   npx tsx apps/web/prisma/seed.ts
 ```
 
-### 11. 各アプリの環境変数ファイルを作成
+### 9. 各アプリの環境変数ファイルを作成
 
 ```bash
 cp apps/web/.env.example apps/web/.env
@@ -172,7 +173,7 @@ cp apps/api/.env.example apps/api/.env
 `apps/web/.env` を編集:
 
 ```
-DATABASE_URL=mysql://dev:pass@localhost:3306/kidoku
+DATABASE_URL=mysql://dev:pass@localhost:13306/kidoku
 NEXT_PUBLIC_ENABLE_BACKDOOR_LOGIN=true
 BACKDOOR_USER_EMAIL=test@example.com
 ```
@@ -180,18 +181,18 @@ BACKDOOR_USER_EMAIL=test@example.com
 `apps/api/.env` を編集:
 
 ```
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku"
+DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku"
 MEILI_HOST=http://localhost:7700
 ```
 
-### 12. Prisma クライアント生成
+### 10. Prisma クライアント生成
 
 ```bash
-PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma@5 generate --schema=apps/web/prisma/schema.prisma
-PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma@5 generate --schema=apps/api/prisma/schema.prisma
+PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate --schema=apps/web/prisma/schema.prisma
+PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate --schema=apps/api/prisma/schema.prisma
 ```
 
-### 13. 開発サーバー起動
+### 11. 開発サーバー起動
 
 **バックエンド（NestJS API）**:
 
@@ -209,7 +210,7 @@ pnpm --filter web dev
 
 `✓ Ready` が表示されれば成功。
 
-### 14. 動作確認
+### 12. 動作確認
 
 **フロントエンド**:
 
@@ -230,17 +231,17 @@ curl -s http://localhost:4000/graphql -X POST \
 **バックエンド（認証付きでデータ取得）**:
 
 GraphQL の `sheets` / `books` クエリは HMAC-SHA256 署名が必要。
-以下のスクリプトでテストユーザーの作成からデータ取得まで確認できる（手順10でseed実行済みの場合、手順1・2はスキップ可）。
+以下のスクリプトでテストユーザーの作成からデータ取得まで確認できる（手順8でseed実行済みの場合、手順1・2はスキップ可）。
 
 ```bash
 # 1. テストユーザー作成
-docker exec kidoku_db mariadb -u dev -ppass kidoku -e "
+docker exec kidoku_db mysql -u dev -ppass kidoku -e "
   INSERT IGNORE INTO users (id, name, email, admin)
   VALUES ('test-user-id', 'testuser', 'test@example.com', 0);
 "
 
 # 2. テストデータ投入（シート＋本）
-docker exec kidoku_db mariadb -u dev -ppass kidoku -e "
+docker exec kidoku_db mysql -u dev -ppass kidoku -e "
   INSERT IGNORE INTO sheets (id, user_id, name, \`order\`)
   VALUES (1, 'test-user-id', 'テスト本棚', 1);
   INSERT IGNORE INTO books (id, user_id, sheet_id, title, author, category, image, impression, memo, is_public_memo, is_purchasable, created, updated)
@@ -356,73 +357,56 @@ node /tmp/screenshot_login.mjs
 ### 1. Docker デーモン起動
 
 ```bash
-sudo -E dockerd --iptables=false --bridge=none --storage-driver=vfs &>/tmp/dockerd.log &
+# プロキシ設定が /etc/docker/daemon.json に残っていれば再設定不要
+sudo -E dockerd &>/tmp/kidoku/dockerd.log &
 sleep 5 && docker info
 ```
 
 ### 2. コンテナ再起動
 
-既存コンテナが残っている場合は `start`、なければ `run` で再作成する。
-
 ```bash
-# 既存コンテナの再起動を試みる
-docker start kidoku_db kidoku_meilisearch 2>/dev/null || {
-  echo "コンテナが存在しないため再作成..."
-  docker run -d --name kidoku_db --network=host \
-    -e MARIADB_ROOT_PASSWORD=pass \
-    -e MARIADB_DATABASE=kidoku \
-    -e MARIADB_USER=dev \
-    -e MARIADB_PASSWORD=pass \
-    mariadb:lts
-  docker run -d --name kidoku_meilisearch --network=host \
-    -e MEILI_HTTP_ADDR=0.0.0.0:7700 \
-    -e MEILI_MASTER_KEY=YourMasterKey \
-    getmeili/meilisearch:prototype-japanese-6
-}
-sleep 15 && docker ps
+docker compose up -d
 ```
 
-> **注意**: コンテナの `start` が失敗する場合（`Error: No such container`）は、先に `docker rm -f kidoku_db kidoku_meilisearch` してから `docker run` で再作成する。
+> コンテナの状態が壊れている場合は `docker compose down && docker compose up -d` で再作成。
 
 ### 3. DB テーブル・データ確認
 
 ```bash
 # テーブルが存在するか確認
-docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SHOW TABLES;"
+docker exec kidoku_db mysql -u dev -ppass kidoku -e "SHOW TABLES;"
 
 # テーブルがなければ再作成
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" \
+DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" \
   npx prisma db push --schema=apps/web/prisma/schema.prisma
 
 # データがなければシード再投入
-DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" \
+DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" \
   npx tsx apps/web/prisma/seed.ts
 ```
 
 ### 4. 開発サーバー起動
 
 ```bash
-# バックエンド
-pnpm --filter api dev > /tmp/api.log 2>&1 &
-sleep 10 && tail -3 /tmp/api.log
+bash scripts/dev-server.sh start
+```
 
-# フロントエンド
-pnpm --filter web dev > /tmp/web.log 2>&1 &
-sleep 20 && curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
-# → 200 が返れば OK
+または自動修復スクリプトで一括対応:
+
+```bash
+bash scripts/auto-fix.sh
 ```
 
 ## 制限事項
 
 | 項目 | 状況 |
 |---|---|
-| Docker デーモン起動 | `--iptables=false --bridge=none --storage-driver=vfs` で可能 |
+| Docker デーモン起動 | エグレスプロキシ設定（`/etc/docker/daemon.json`）が必要 |
 | Docker Hub 接続 | プロキシ経由で到達可能 |
-| イメージ pull（Alpine系） | **可能**（alpine, node:20-alpine, mariadb:lts, meilisearch等） |
-| イメージ pull（非Alpine系） | **不可**（mysql:9.3等はレイヤー展開時に`operation not permitted`） |
-| `docker compose up` | overlayfsの制限により不可。`docker run`で個別起動すること |
-| ブリッジネットワーク | 無効化しているため `--network=host` が必要 |
-| MySQL | pull不可のため **MariaDB（`mariadb:lts`）で代替**すること |
+| イメージ pull | **可能**（mysql:9.3, mariadb, meilisearch, node, alpine 等） |
+| `docker compose up` | **可能**（プロキシ設定済みのデーモンで正常動作） |
+| DB ポート | docker-compose.yml で `13306:3306` にマッピング |
+| 外部DB接続（TCP直接） | **不可**（MySQL/TiDB Cloud 等へのTCP直接接続はブロック。HTTP(S)プロキシ経由のみ通信可能） |
 | Playwright MCP / Chrome DevTools MCP | **使用不可**（後述） |
 
 ## MCP によるブラウザ操作の制限
@@ -573,5 +557,6 @@ node /tmp/browser_action.mjs
 
 - **MCP ブラウザツール非対応**: Playwright MCP・Chrome DevTools MCP は Claude Code on the Web では動作しない。上記の Playwright スクリプト方式を使うこと
 - **外部サービスへの接続制限**: Google Fonts、Prisma Accelerate等への接続がブロックされる場合がある
+- **外部DB接続不可**: TiDB Cloud 等への MySQL TCP 直接接続はサンドボックスのネットワーク制限でブロックされる（HTTP(S)プロキシ経由の通信のみ可能）
 - **ページ表示エラー**: DB接続エラーはサンドボックスのネットワーク制限が原因の場合があり、コード自体の問題ではない
 - **`pnpm dev`の起動確認**: TypeScriptコンパイルエラー0件、Next.js/NestJSの起動成功メッセージで判断する

--- a/scripts/auto-fix.sh
+++ b/scripts/auto-fix.sh
@@ -34,11 +34,23 @@ fix_docker() {
     return 0
   fi
   yellow "Docker デーモンを起動中..."
-  if command -v update-alternatives &>/dev/null; then
-    sudo update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
-    sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+
+  # サンドボックスのエグレスプロキシを Docker デーモンに設定
+  if [ -n "${HTTP_PROXY:-}" ]; then
+    sudo mkdir -p /etc/docker
+    cat <<DAEMON_EOF | sudo tee /etc/docker/daemon.json >/dev/null
+{
+  "proxies": {
+    "http-proxy": "${HTTP_PROXY}",
+    "https-proxy": "${HTTPS_PROXY:-${HTTP_PROXY}}",
+    "no-proxy": "localhost,127.0.0.1"
+  },
+  "dns": ["8.8.8.8", "8.8.4.4"]
+}
+DAEMON_EOF
   fi
-  sudo -E dockerd --iptables=false --bridge=none --storage-driver=vfs &>"$LOG_DIR/dockerd.log" &
+
+  sudo -E dockerd &>"$LOG_DIR/dockerd.log" &
   for i in $(seq 1 30); do
     if docker info &>/dev/null; then
       green "Docker: 修復完了"
@@ -53,7 +65,7 @@ fix_docker() {
 }
 
 # ==============================================================================
-# MariaDB 修復
+# MySQL 修復（docker compose 経由）
 # ==============================================================================
 fix_db() {
   # Docker が必要
@@ -61,46 +73,39 @@ fix_db() {
     fix_docker || return 1
   fi
 
-  if docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
-    green "MariaDB: 正常"
+  if docker exec kidoku_db mysql -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
+    green "MySQL: 正常"
     return 0
   fi
 
-  # コンテナが存在するが停止している場合
-  if docker ps -a --format '{{.Names}}' | grep -q '^kidoku_db$'; then
-    yellow "MariaDB コンテナを再起動中..."
-    docker start kidoku_db
-  else
-    yellow "MariaDB コンテナを作成中..."
-    docker run -d --name kidoku_db --network=host \
-      -e MARIADB_ROOT_PASSWORD=pass \
-      -e MARIADB_DATABASE=kidoku \
-      -e MARIADB_USER=dev \
-      -e MARIADB_PASSWORD=pass \
-      mariadb:lts
+  # docker compose で起動（.env がなければ作成）
+  cd "$PROJECT_ROOT"
+  if [ ! -f "$PROJECT_ROOT/.env" ]; then
+    cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
   fi
+
+  yellow "MySQL コンテナを docker compose で起動中..."
+  docker compose up -d db 2>"$LOG_DIR/docker-compose.log"
 
   # 接続待ち
   for i in $(seq 1 30); do
-    if docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
-      green "MariaDB: 修復完了"
+    if docker exec kidoku_db mysql -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
+      green "MySQL: 修復完了"
       FIXED=$((FIXED + 1))
 
       # テーブルが存在するか確認
-      TABLE_COUNT=$(docker exec kidoku_db mariadb -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='kidoku'" 2>/dev/null || echo "0")
+      TABLE_COUNT=$(docker exec kidoku_db mysql -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='kidoku'" 2>/dev/null || echo "0")
       if [ "$TABLE_COUNT" -eq 0 ] 2>/dev/null; then
         yellow "テーブルが存在しません。Prisma db push を実行中..."
-        cd "$PROJECT_ROOT"
-        DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" pnpm --filter web exec prisma db push --skip-generate 2>"$LOG_DIR/prisma-push.log"
+        DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" pnpm --filter web exec prisma db push --skip-generate 2>"$LOG_DIR/prisma-push.log"
         green "Prisma db push 完了"
       fi
 
       # ユーザーが存在するか確認
-      USER_COUNT=$(docker exec kidoku_db mariadb -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
+      USER_COUNT=$(docker exec kidoku_db mysql -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
       if [ "$USER_COUNT" -eq 0 ] 2>/dev/null; then
         yellow "シードデータを投入中..."
-        cd "$PROJECT_ROOT"
-        DATABASE_URL="mysql://dev:pass@localhost:3306/kidoku" node scripts/sandbox-seed.js 2>"$LOG_DIR/seed.log" || true
+        DATABASE_URL="mysql://dev:pass@localhost:13306/kidoku" node scripts/sandbox-seed.js 2>"$LOG_DIR/seed.log" || true
         green "シードデータ投入完了"
       fi
 
@@ -108,13 +113,13 @@ fix_db() {
     fi
     sleep 1
   done
-  red "MariaDB: 修復失敗"
+  red "MySQL: 修復失敗"
   FAILED=$((FAILED + 1))
   return 1
 }
 
 # ==============================================================================
-# MeiliSearch 修復
+# MeiliSearch 修復（docker compose 経由）
 # ==============================================================================
 fix_meili() {
   if ! docker info &>/dev/null; then
@@ -126,16 +131,20 @@ fix_meili() {
     return 0
   fi
 
-  if docker ps -a --format '{{.Names}}' | grep -q '^kidoku_meilisearch$'; then
-    yellow "MeiliSearch コンテナを再起動中..."
-    docker start kidoku_meilisearch
-  else
-    yellow "MeiliSearch コンテナを作成中..."
-    docker run -d --name kidoku_meilisearch --network=host \
-      -e MEILI_HTTP_ADDR=0.0.0.0:7700 \
-      -e MEILI_MASTER_KEY=YourMasterKey \
-      getmeili/meilisearch:prototype-japanese-6
+  cd "$PROJECT_ROOT"
+  if [ ! -f "$PROJECT_ROOT/.env" ]; then
+    cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
   fi
+
+  # データディレクトリの互換性問題がある場合はクリア
+  if docker compose logs meilisearch 2>/dev/null | grep -q "failed to infer the version"; then
+    yellow "MeiliSearch データをクリア中（バージョン不一致）..."
+    docker compose rm -f meilisearch 2>/dev/null || true
+    rm -rf "$PROJECT_ROOT/docker/meilisearch/data/meilisearch"
+  fi
+
+  yellow "MeiliSearch コンテナを docker compose で起動中..."
+  docker compose up -d meilisearch 2>"$LOG_DIR/docker-compose.log"
 
   for i in $(seq 1 20); do
     if curl -s -o /dev/null -w '%{http_code}' http://localhost:7700/health 2>/dev/null | grep -q '200'; then

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -26,34 +26,34 @@ else
   check_fail "Docker デーモンが起動していません"
 fi
 
-# --- MariaDB ---
-echo "--- MariaDB ---"
+# --- MySQL ---
+echo "--- MySQL ---"
 if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kidoku_db$'; then
-  check_pass "MariaDB コンテナ起動中"
-  if docker exec kidoku_db mariadb -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
-    check_pass "MariaDB 接続可能"
-    TABLE_COUNT=$(docker exec kidoku_db mariadb -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='kidoku'" 2>/dev/null || echo "0")
+  check_pass "MySQL コンテナ起動中"
+  if docker exec kidoku_db mysql -u dev -ppass kidoku -e "SELECT 1" &>/dev/null; then
+    check_pass "MySQL 接続可能"
+    TABLE_COUNT=$(docker exec kidoku_db mysql -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='kidoku'" 2>/dev/null || echo "0")
     if [ "$TABLE_COUNT" -gt 0 ] 2>/dev/null; then
       check_pass "テーブル存在 ($TABLE_COUNT テーブル)"
     else
       check_fail "テーブルが存在しません (prisma db push が必要)"
     fi
-    USER_COUNT=$(docker exec kidoku_db mariadb -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
+    USER_COUNT=$(docker exec kidoku_db mysql -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
     if [ "$USER_COUNT" -gt 0 ] 2>/dev/null; then
       check_pass "シードデータ存在 (users: $USER_COUNT 件)"
     else
       check_warn "シードデータなし (seed 実行を推奨)"
     fi
   else
-    check_fail "MariaDB に接続できません"
+    check_fail "MySQL に接続できません"
   fi
 else
-  check_fail "MariaDB コンテナが起動していません"
+  check_fail "MySQL コンテナが起動していません"
 fi
 
 # --- MeiliSearch ---
 echo "--- MeiliSearch ---"
-if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^kidoku_meilisearch$'; then
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'meilisearch'; then
   check_pass "MeiliSearch コンテナ起動中"
   if curl -s -o /dev/null -w '%{http_code}' http://localhost:7700/health 2>/dev/null | grep -q '200'; then
     check_pass "MeiliSearch ヘルスチェック OK"

--- a/scripts/sandbox-setup.sh
+++ b/scripts/sandbox-setup.sh
@@ -43,21 +43,30 @@ fi
 green "依存パッケージのインストール完了"
 
 # ==============================================================================
-# 3. iptables を legacy に切り替え
-# ==============================================================================
-if command -v update-alternatives &>/dev/null; then
-  yellow "iptables を legacy モードに切り替え中..."
-  sudo update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
-  sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
-  green "iptables 設定完了"
-fi
-
-# ==============================================================================
-# 4. Docker デーモン起動
+# 3. Docker デーモン起動（プロキシ設定付き）
 # ==============================================================================
 if ! docker info &>/dev/null; then
   yellow "Docker デーモンを起動中..."
-  sudo -E dockerd --iptables=false --bridge=none --storage-driver=vfs &>"$LOG_DIR/dockerd.log" &
+
+  # サンドボックスのエグレスプロキシを Docker デーモンに設定
+  # curl/npm 等は HTTP_PROXY 環境変数で外部通信できるが、Docker デーモンは
+  # daemon.json の proxies 設定が必要
+  if [ -n "${HTTP_PROXY:-}" ]; then
+    sudo mkdir -p /etc/docker
+    cat <<DAEMON_EOF | sudo tee /etc/docker/daemon.json >/dev/null
+{
+  "proxies": {
+    "http-proxy": "${HTTP_PROXY}",
+    "https-proxy": "${HTTPS_PROXY:-${HTTP_PROXY}}",
+    "no-proxy": "localhost,127.0.0.1"
+  },
+  "dns": ["8.8.8.8", "8.8.4.4"]
+}
+DAEMON_EOF
+    green "Docker プロキシ設定完了"
+  fi
+
+  sudo -E dockerd &>"$LOG_DIR/dockerd.log" &
   # デーモン起動待ち（最大30秒）
   for i in $(seq 1 30); do
     if docker info &>/dev/null; then
@@ -76,71 +85,39 @@ else
 fi
 
 # ==============================================================================
-# 5. DB コンテナ起動（MariaDB）
+# 4. docker compose でコンテナ起動（MySQL + MeiliSearch）
 # ==============================================================================
-if docker ps --format '{{.Names}}' | grep -q '^kidoku_db$'; then
-  green "MariaDB コンテナは既に起動済み"
-elif docker ps -a --format '{{.Names}}' | grep -q '^kidoku_db$'; then
-  yellow "MariaDB コンテナを再起動中..."
-  docker start kidoku_db
-  green "MariaDB コンテナ再起動完了"
-else
-  yellow "MariaDB コンテナを作成中..."
-  docker run -d --name kidoku_db --network=host \
-    -e MARIADB_ROOT_PASSWORD=pass \
-    -e MARIADB_DATABASE=kidoku \
-    -e MARIADB_USER=dev \
-    -e MARIADB_PASSWORD=pass \
-    mariadb:lts
-  green "MariaDB コンテナ作成完了"
+yellow "docker compose でコンテナを起動中..."
+cd "$PROJECT_ROOT"
+
+# .env がなければ .env.example からコピー（docker-compose.yml が参照する変数用）
+if [ ! -f "$PROJECT_ROOT/.env" ]; then
+  cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
+  green ".env ファイル生成完了"
 fi
 
-# ==============================================================================
-# 6. MeiliSearch コンテナ起動
-# ==============================================================================
-if docker ps --format '{{.Names}}' | grep -q '^kidoku_meilisearch$'; then
-  green "MeiliSearch コンテナは既に起動済み"
-elif docker ps -a --format '{{.Names}}' | grep -q '^kidoku_db$'; then
-  yellow "MeiliSearch コンテナを再起動中..."
-  docker start kidoku_meilisearch 2>/dev/null || {
-    docker run -d --name kidoku_meilisearch --network=host \
-      -e MEILI_HTTP_ADDR=0.0.0.0:7700 \
-      -e MEILI_MASTER_KEY=YourMasterKey \
-      getmeili/meilisearch:prototype-japanese-6
-  }
-  green "MeiliSearch コンテナ起動完了"
-else
-  yellow "MeiliSearch コンテナを作成中..."
-  docker run -d --name kidoku_meilisearch --network=host \
-    -e MEILI_HTTP_ADDR=0.0.0.0:7700 \
-    -e MEILI_MASTER_KEY=YourMasterKey \
-    getmeili/meilisearch:prototype-japanese-6
-  green "MeiliSearch コンテナ作成完了"
-fi
+# docker compose up（イメージ未取得ならpullも実行）
+docker compose up -d 2>"$LOG_DIR/docker-compose.log"
+green "docker compose up 完了"
 
-# コンテナ起動待ち
-yellow "コンテナの起動を待機中..."
+# DB コンテナ起動待ち（最大30秒）
+yellow "MySQL の起動を待機中..."
 for i in $(seq 1 30); do
-  if docker exec kidoku_db mariadb -u dev -ppass -e "SELECT 1" &>/dev/null; then
+  if docker exec kidoku_db mysql -u dev -ppass -e "SELECT 1" &>/dev/null; then
     break
   fi
   sleep 1
 done
-green "コンテナ起動確認完了"
-
-# ==============================================================================
-# 7. 環境変数ファイル生成
-# ==============================================================================
-DB_URL="mysql://dev:pass@localhost:3306/kidoku"
-
-if [ ! -f "$PROJECT_ROOT/.env" ]; then
-  cp "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env"
-  sed -i 's|DB_HOST=.*|DB_HOST=localhost|' "$PROJECT_ROOT/.env"
-  sed -i 's|DB_PORT=.*|DB_PORT=3306|' "$PROJECT_ROOT/.env"
-  green ".env ファイル生成完了"
+if docker exec kidoku_db mysql -u dev -ppass -e "SELECT 1" &>/dev/null; then
+  green "MySQL 起動確認完了"
 else
-  green ".env ファイルは既に存在"
+  red "MySQL の起動に失敗しました。ログ: docker compose logs db"
 fi
+
+# ==============================================================================
+# 5. 環境変数ファイル生成
+# ==============================================================================
+DB_URL="mysql://dev:pass@localhost:13306/kidoku"
 
 if [ ! -f "$PROJECT_ROOT/apps/web/.env" ]; then
   cp "$PROJECT_ROOT/apps/web/.env.example" "$PROJECT_ROOT/apps/web/.env"
@@ -168,7 +145,7 @@ sed -i "s|^DATABASE_URL=.*|DATABASE_URL=\"$DB_URL\"|" "$PROJECT_ROOT/apps/api/.e
 sed -i 's|^MEILI_HOST=.*|MEILI_HOST=http://localhost:7700|' "$PROJECT_ROOT/apps/api/.env"
 
 # ==============================================================================
-# 8. Prisma スキーマ反映 + クライアント生成
+# 6. Prisma スキーマ反映 + クライアント生成
 # ==============================================================================
 yellow "Prisma スキーマを DB に反映中..."
 DATABASE_URL="$DB_URL" pnpm --filter web exec prisma db push --skip-generate 2>"$LOG_DIR/prisma-push.log"
@@ -180,9 +157,9 @@ PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter api exec prisma generate 
 green "Prisma クライアント生成完了"
 
 # ==============================================================================
-# 9. シードデータ投入
+# 7. シードデータ投入
 # ==============================================================================
-SEED_CHECK=$(docker exec kidoku_db mariadb -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
+SEED_CHECK=$(docker exec kidoku_db mysql -u dev -ppass kidoku -N -e "SELECT COUNT(*) FROM users" 2>/dev/null || echo "0")
 if [ "$SEED_CHECK" = "0" ] || [ "$SEED_CHECK" = "" ]; then
   yellow "シードデータを投入中..."
   DATABASE_URL="$DB_URL" node "$PROJECT_ROOT/scripts/sandbox-seed.js" 2>"$LOG_DIR/seed.log" || {
@@ -194,7 +171,7 @@ else
 fi
 
 # ==============================================================================
-# 10. MeiliSearch シードデータ投入
+# 8. MeiliSearch シードデータ投入
 # ==============================================================================
 MEILI_HEALTH=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:7700/health 2>/dev/null || echo "000")
 if [ "$MEILI_HEALTH" = "200" ]; then
@@ -217,12 +194,12 @@ else
 fi
 
 # ==============================================================================
-# 11. 開発サーバー起動
+# 9. 開発サーバー起動
 # ==============================================================================
 "$SCRIPT_DIR/dev-server.sh" start
 
 # ==============================================================================
-# 12. ヘルスチェック
+# 10. ヘルスチェック
 # ==============================================================================
 "$SCRIPT_DIR/health-check.sh"
 


### PR DESCRIPTION
## 概要

サンドボックス環境のセットアップ手順を大幅に簡素化し、MariaDB から MySQL 9.3 への移行、および `docker run` による個別起動から `docker compose` への統一を実施しました。

主な変更:
- **DB の変更**: MariaDB → MySQL 9.3（docker-compose.yml で管理）
- **コンテナ起動方式**: `docker run` での個別起動 → `docker compose up` での一括管理
- **Docker デーモン設定**: `--iptables=false --bridge=none --storage-driver=vfs` の廃止 → エグレスプロキシ設定（`daemon.json`）に統一
- **ポートマッピング**: `localhost:3306` → `localhost:13306`（docker-compose.yml で `13306:3306` にマッピング）
- **iptables 設定**: 不要になったため削除

## 変更の種類

- [x] Refactoring
- [x] Documentation

## 詳細

### ドキュメント更新（docs/SANDBOX_SETUP.md）

1. **前提条件の簡潔化**
   - `nftables` 非対応、iptables legacy 切り替えの記述を削除
   - Docker Compose v5 対応を明記

2. **セットアップ手順の簡素化**
   - iptables 設定ステップを削除
   - `docker run` での個別起動（MariaDB + MeiliSearch）→ `docker compose up -d` に統一
   - DB ポートを `3306` → `13306` に変更（docker-compose.yml のマッピング経由）
   - Docker デーモン起動時にエグレスプロキシ設定を自動適用

3. **制限事項の更新**
   - `docker compose up` が **可能** に変更（プロキシ設定済みで正常動作）
   - MySQL イメージ pull が **可能** に変更（MariaDB 代替不要）
   - ブリッジネットワーク制限の記述を削除
   - 外部 DB 接続（TCP 直接）の制限を明記

4. **トラブルシューティング**
   - MeiliSearch バージョン不一致エラーの対処法を追加
   - `docker compose` コマンドの使用例に統一

### スクリプト更新

#### scripts/sandbox-setup.sh
- iptables legacy 切り替えステップを削除
- Docker デーモン起動時にエグレスプロキシ設定を自動生成
- `docker run` での MariaDB/MeiliSearch 起動 → `docker compose up -d` に統一
- DB 接続 URL を `localhost:3306` → `localhost:13306` に変更
- `mariadb` コマンド → `mysql` コマンドに統一

#### scripts/auto-fix.sh
- Docker 修復時のプロキシ設定を自動適用
- MariaDB 修復 → MySQL 修復に変更（docker compose 経由）
- MeiliSearch 修復を docker compose 経由に変更
- バージョン不一致エラー時のデータクリア処理を追加

#### scripts/health-check.sh
- `mariadb` コマンド → `mysql` コマンドに統一
- コンテナ名検出を `kidoku_meilisearch` → `meilisearch` に変更（docker-compose 命名規則対応）

### その他の更新

- CLAUDE.md:

https://claude.ai/code/session_017ffS3cbavzTaDP6UjrxDET