### PR TITLE
feat: コメント一覧から本クリック時に詳細ページへ遷移するように変更

### DIFF
--- a/apps/web/src/components/layout/BookComment.tsx
+++ b/apps/web/src/components/layout/BookComment.tsx
@@ -22,13 +22,13 @@ export const BookComment: React.FC<Props> = ({ comment }) => {
   return (
     <div className="flex items-center p-4">
       <div className="pr-4 text-center">
-        <Link href={`/${username}/sheets/${sheet}?book=${comment.id}`}>
+        <Link href={`/books/${comment.id}`}>
           <img className="mb-1 w-[82px] min-w-[82px]" src={image} alt="" />
         </Link>
       </div>
       <div>
         <Link
-          href={`/${username}/sheets/${sheet}?book=${comment.id}`}
+          href={`/books/${comment.id}`}
           className="mb-2 block text-xs font-bold sm:text-sm"
         >
           <div className="line-clamp-3">


### PR DESCRIPTION
サイドバーを開く代わりに /books/{id} の詳細ページに直接遷移するようにリンク先を変更。

https://claude.ai/code/session_011q2RVyGENp7qycTdcnDV7K