### PR TITLE
feat(web): アプリ内 SNS 共有とシート/ブックの動的 OGP を追加

### DIFF
--- a/apps/web/src/features/books/components/BookPage.tsx
+++ b/apps/web/src/features/books/components/BookPage.tsx
@@ -8,6 +8,7 @@ import { MdChevronRight } from 'react-icons/md'
 import { useIsBookOwner } from '@/hooks/useIsBookOwner'
 import apolloClient from '@/libs/apollo'
 import { getBookQuery } from '@/features/books/api/queries'
+import { NextSeo } from 'next-seo'
 
 interface BookPageProps {
   book: Book | null
@@ -73,9 +74,24 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
 
   const sheetUrl =
     book.user && book.sheet ? `/${book.user.name}/sheets/${book.sheet}` : null
+  const host = process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'
+  const ogImage = `${host}/api/og?type=book&user=${encodeURIComponent(book.user?.name ?? 'kidoku user')}&title=${encodeURIComponent(book.title)}&author=${encodeURIComponent(book.author)}&category=${encodeURIComponent(book.category)}`
+  const pageUrl = `${host}/books/${book.id}`
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <NextSeo
+        title={`${book.title} | kidoku`}
+        description={`${book.author} / ${book.category} の読書メモ`}
+        canonical={pageUrl}
+        openGraph={{
+          title: `${book.title} | kidoku`,
+          description: `${book.author} / ${book.category} の読書メモ`,
+          url: pageUrl,
+          images: [{ url: ogImage, width: 1200, height: 630 }],
+        }}
+        twitter={{ cardType: 'summary_large_image' }}
+      />
       <div className="mx-auto max-w-4xl py-8">
         {sheetUrl && (
           <nav

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -16,6 +16,8 @@ import { Loading } from '@/components/icon/Loading'
 import { Tooltip } from 'react-tooltip'
 import { Memo } from './Memo'
 import { FaLink } from 'react-icons/fa'
+import { FiShare2 } from 'react-icons/fi'
+import { shareToSns } from '@/utils/socialShare'
 
 interface Props {
   book: Book
@@ -29,8 +31,9 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
   const [loading, setLoading] = useState(false)
 
   const returnUrl = () => {
-    return `${process.env.NEXT_PUBLIC_HOST}/books/${book.id}`
+    return `${process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'}/books/${book.id}`
   }
+  const shareUrl = returnUrl()
 
   return (
     <div className="flex h-full min-w-full flex-col justify-between rounded-md">
@@ -40,8 +43,7 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
             <button
               className="rounded-full bg-gray-200 p-2 hover:brightness-95"
               onClick={() => {
-                const url = returnUrl()
-                navigator.clipboard.writeText(url)
+                navigator.clipboard.writeText(shareUrl)
               }}
               onMouseDown={(e) => e.preventDefault()}
               data-tooltip-id="share-button"
@@ -50,6 +52,20 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
               <FaLink size={18} />
             </button>
             <Tooltip id="share-button" />
+            <button
+              className="rounded-full bg-slate-800 p-2 text-white hover:bg-slate-700"
+              onClick={() =>
+                shareToSns(
+                  `『${book.title}』を読了しました📚 #kidoku`,
+                  shareUrl
+                )
+              }
+              data-tooltip-id="book-sns-share"
+              data-tooltip-content="SNSで共有"
+            >
+              <FiShare2 size={18} />
+            </button>
+            <Tooltip id="book-sns-share" />
 
             {isMine && onEdit && (
               <button

--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -24,6 +24,8 @@ import { twMerge } from 'tailwind-merge'
 import { useQuery } from '@apollo/client'
 import { getBooksQuery } from '@/features/books/api'
 import dayjs from 'dayjs'
+import { FiShare2 } from 'react-icons/fi'
+import { shareToSns } from '@/utils/socialShare'
 
 const CategoryPieChart = dynamic(
   () => import('./CategoryPieChart').then((mod) => mod.CategoryPieChart),
@@ -113,6 +115,22 @@ export const SheetPage: React.FC<Props> = ({
   const [fullPageBook, setFullPageBook] = useState<Book>(null)
 
   const isMine = session && session.user.id === userId
+  const host = process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'
+  const pageUrl = `${host}/${encodeURIComponent(username)}/sheets/${encodeURIComponent(year)}`
+  const monthlySummary = useMemo(() => {
+    const counts = data.reduce(
+      (acc, book) => {
+        acc[book.month] = (acc[book.month] ?? 0) + 1
+        return acc
+      },
+      {} as Record<string, number>
+    )
+    const entries = Object.entries(counts).sort((a, b) => b[1] - a[1])
+    if (entries.length === 0) return '今月の記録はまだありません。'
+    const [month, count] = entries[0]
+    return `${year}は合計${data.length}冊。最も読んだのは${month}で${count}冊でした。`
+  }, [data, year])
+  const ogImage = `${host}/api/og?type=year&user=${encodeURIComponent(username)}&title=${encodeURIComponent(`${year}年の読書まとめ`)}&subtitle=${encodeURIComponent('今年読んだ冊数')}&count=${data.length}`
 
   // シート切り替え時にステートをリセット
   useEffect(() => {
@@ -180,7 +198,11 @@ export const SheetPage: React.FC<Props> = ({
   if (data.length === 0) {
     return (
       <Container>
-        <NextSeo title={`${username}/${year} | kidoku`} />
+        <NextSeo
+          title={`${username}/${year} | kidoku`}
+          openGraph={{ images: [{ url: ogImage, width: 1200, height: 630 }] }}
+          twitter={{ cardType: 'summary_large_image' }}
+        />
         <SheetTabsWithMenu
           sheets={sheets}
           currentSheet={year}
@@ -200,7 +222,16 @@ export const SheetPage: React.FC<Props> = ({
 
   return (
     <Container className="mb-12">
-      <NextSeo title={`${username}/${year} | kidoku`} />
+      <NextSeo
+        title={`${username}/${year} | kidoku`}
+        description={monthlySummary}
+        openGraph={{
+          title: `${username}の${year}読書まとめ`,
+          description: monthlySummary,
+          images: [{ url: ogImage, width: 1200, height: 630 }],
+        }}
+        twitter={{ cardType: 'summary_large_image' }}
+      />
       <SheetTabsWithMenu
         sheets={sheets}
         currentSheet={year}
@@ -211,6 +242,18 @@ export const SheetPage: React.FC<Props> = ({
       <div className="mt-32 text-center">
         <TitleWithLine text="累計読書数" />
         <CoutUpText value={data.length} unit="冊" step={1} />
+        <button
+          className="mx-auto mt-3 flex items-center gap-2 rounded-full bg-slate-800 px-4 py-2 text-sm text-white hover:bg-slate-700"
+          onClick={() =>
+            shareToSns(
+              `${username}の${year}読書まとめ📚 合計${data.length}冊を記録しました！`,
+              pageUrl
+            )
+          }
+        >
+          <FiShare2 />
+          読了数をシェア
+        </button>
       </div>
 
       <div className="mb-10">
@@ -233,6 +276,13 @@ export const SheetPage: React.FC<Props> = ({
       <div className="mb-14 flex w-full flex-wrap justify-center">
         <div className="w-full text-center sm:w-1/2">
           <TitleWithLine text="月ごとの読書数" className="mb-4" />
+          <button
+            className="mx-auto mb-4 flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100"
+            onClick={() => shareToSns(`📈 ${monthlySummary}`, pageUrl)}
+          >
+            <FiShare2 />
+            月次サマリーをシェア
+          </button>
           <BarGraph
             records={data}
             setShowData={setShowData}

--- a/apps/web/src/pages/api/og.tsx
+++ b/apps/web/src/pages/api/og.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from '@vercel/og'
+
+export const config = {
+  runtime: 'edge',
+}
+
+const width = 1200
+const height = 630
+
+const baseStyle = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  justifyContent: 'space-between',
+  padding: '56px',
+  background:
+    'linear-gradient(135deg, rgba(249,250,251,1) 0%, rgba(236,253,245,1) 50%, rgba(224,242,254,1) 100%)',
+  color: '#0f172a',
+  fontFamily:
+    'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+}
+
+const cardStyle = {
+  borderRadius: '24px',
+  backgroundColor: 'rgba(255,255,255,0.82)',
+  border: '1px solid rgba(148,163,184,0.25)',
+  padding: '28px 32px',
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '14px',
+}
+
+const trim = (text: string, max: number) =>
+  text.length > max ? `${text.slice(0, max - 1)}…` : text
+
+export default function handler(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const type = searchParams.get('type') ?? 'year'
+  const user = trim(searchParams.get('user') ?? 'kidoku user', 24)
+
+  const title =
+    type === 'book'
+      ? trim(searchParams.get('title') ?? '本の詳細', 44)
+      : trim(searchParams.get('title') ?? '今年読んだ冊数', 28)
+  const subtitle =
+    type === 'book'
+      ? trim(searchParams.get('author') ?? 'book detail', 50)
+      : trim(searchParams.get('subtitle') ?? '読書記録サマリー', 52)
+  const value =
+    type === 'book'
+      ? trim(searchParams.get('category') ?? '', 20)
+      : `${searchParams.get('count') ?? '0'}冊`
+
+  return new ImageResponse(
+    <div style={baseStyle}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <div
+          style={{
+            fontSize: 38,
+            fontWeight: 700,
+            color: '#0f766e',
+          }}
+        >
+          kidoku
+        </div>
+        <div style={{ fontSize: 28, color: '#334155' }}>読書記録をシェア</div>
+      </div>
+
+      <div style={cardStyle}>
+        <div style={{ fontSize: 28, color: '#334155' }}>{user}</div>
+        <div style={{ fontSize: 68, fontWeight: 800, lineHeight: 1.1 }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 34, color: '#334155' }}>{subtitle}</div>
+        {value ? (
+          <div style={{ fontSize: 48, fontWeight: 700, color: '#0f766e' }}>
+            {value}
+          </div>
+        ) : null}
+      </div>
+
+      <div style={{ fontSize: 26, color: '#475569' }}>https://kidoku.net</div>
+    </div>,
+    {
+      width,
+      height,
+    }
+  )
+}

--- a/apps/web/src/utils/socialShare.ts
+++ b/apps/web/src/utils/socialShare.ts
@@ -1,0 +1,25 @@
+export const createXShareUrl = (text: string, url: string) => {
+  const params = new URLSearchParams({
+    text,
+    url,
+  })
+  return `https://twitter.com/intent/tweet?${params.toString()}`
+}
+
+export const shareToSns = async (text: string, url: string) => {
+  if (typeof window === 'undefined') return
+
+  if (navigator.share) {
+    try {
+      await navigator.share({
+        text,
+        url,
+      })
+      return
+    } catch {
+      // キャンセル時はフォールバックでX投稿画面を開く
+    }
+  }
+
+  window.open(createXShareUrl(text, url), '_blank', 'noopener,noreferrer')
+}


### PR DESCRIPTION
### Motivation
- Provide in-app SNS sharing entry points so users can share yearly/monthly reading summaries and individual book pages.  
- Unify visual appearance for social cards by generating OGP images from a single dynamic endpoint.  
- Prefer native share API when available and fall back to an X (Twitter) intent URL for broad compatibility.

### Description
- Added an Edge OGP generator `apps/web/src/pages/api/og.tsx` that produces unified share images for `type=year` (yearly summary) and `type=book` (book detail) using `@vercel/og`.  
- Added a share utility `apps/web/src/utils/socialShare.ts` that prefers `navigator.share` and falls back to an X intent URL.  
- Wired sharing and OGP into UI: updated `apps/web/src/features/sheet/components/SheetPage.tsx` to compute a monthly summary, expose `NextSeo` with the generated OGP image, and add “読了数をシェア” and “月次サマリーをシェア” buttons.  
- Updated `apps/web/src/features/books/components/BookPage.tsx` to set page-level `NextSeo` with a book OGP URL and `apps/web/src/features/sheet/components/BookDetailReadModal.tsx` to add an SNS share button next to the copy-link button and to use a safe `NEXT_PUBLIC_HOST` fallback.

### Testing
- Ran lint autofix with `pnpm --filter web exec eslint src/pages/api/og.tsx --fix` which resolved formatting issues.  
- Ran full lint check with `pnpm --filter web exec eslint src/features/sheet/components/SheetPage.tsx src/features/books/components/BookPage.tsx src/features/sheet/components/BookDetailReadModal.tsx src/utils/socialShare.ts src/pages/api/og.tsx` and it passed after the fix.  
- Ran type checks with `pnpm --filter web check-types` (`tsc --noEmit`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8fbafc064832eb415abb664969a5a)