### PR TITLE
Add 'Register Book' action to bottom navigation

### DIFF
--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -6,16 +6,21 @@ import {
   AiFillHome,
   AiOutlineBook,
   AiFillBook,
+  AiOutlinePlusCircle,
+  AiFillPlusCircle,
   AiOutlineSetting,
   AiFillSetting,
 } from 'react-icons/ai'
+import { useAtom } from 'jotai'
 import { useCachedSession } from '@/hooks/useCachedSession'
 import { useReadingRecordsUrl } from '@/hooks/useReadingRecordsUrl'
+import { openSearchModalAtom } from '@/store/modal/atom'
 
 export const BottomNav: React.FC = () => {
   const router = useRouter()
   const { session, status } = useCachedSession()
   const readingRecordsUrl = useReadingRecordsUrl()
+  const [, setOpenSearchModal] = useAtom(openSearchModalAtom)
 
   const navigationItems = useMemo(() => {
     const isHomePage = router.pathname === '/'
@@ -38,6 +43,13 @@ export const BottomNav: React.FC = () => {
         isActive: isSheetsPage,
       },
       {
+        name: '本を登録',
+        icon: AiOutlinePlusCircle,
+        activeIcon: AiFillPlusCircle,
+        isActive: false,
+        onClick: () => setOpenSearchModal(true),
+      },
+      {
         name: '設定',
         href: '/settings/profile',
         icon: AiOutlineSetting,
@@ -45,7 +57,7 @@ export const BottomNav: React.FC = () => {
         isActive: isSettingsPage,
       },
     ]
-  }, [readingRecordsUrl, router.pathname])
+  }, [readingRecordsUrl, router.pathname, setOpenSearchModal])
 
   if (status !== 'authenticated' || !session) {
     return null
@@ -63,15 +75,31 @@ export const BottomNav: React.FC = () => {
       <div className="mx-auto flex h-14 max-w-screen-xl items-center justify-around">
         {navigationItems.map((item) => {
           const Icon = item.isActive ? item.activeIcon : item.icon
+          const classes = `flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-xs transition-colors ${
+            item.isActive
+              ? 'font-semibold text-gray-900'
+              : 'text-gray-500 hover:text-gray-700'
+          }`
+
+          if (item.onClick) {
+            return (
+              <button
+                key={item.name}
+                type="button"
+                className={classes}
+                onClick={item.onClick}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span>{item.name}</span>
+              </button>
+            )
+          }
+
           return (
             <Link
               key={item.name}
-              href={item.href}
-              className={`flex flex-1 flex-col items-center justify-center gap-0.5 py-1 text-xs transition-colors ${
-                item.isActive
-                  ? 'font-semibold text-gray-900'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
+              href={item.href!}
+              className={classes}
               aria-current={item.isActive ? 'page' : undefined}
             >
               <Icon className="h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
### Motivation
- Provide a convenient footer entrypoint so authenticated users can open the book search/registration flow from the bottom navigation.

### Description
- Added a new "本を登録" navigation item that opens the existing search/register modal by setting `openSearchModalAtom` to `true` when clicked.
- Imported `AiOutlinePlusCircle`, `AiFillPlusCircle`, and `useAtom`, and wired `openSearchModalAtom` inside `BottomNav` in `apps/web/src/components/layout/BottomNav.tsx`.
- Updated the navigation rendering to support both link-based items and button actions while preserving existing active-state styling.
- Kept existing items (`ホーム`, `読書記録`, `設定`) unchanged aside from the unified rendering adjustments.

### Testing
- Ran TypeScript check with `pnpm -C apps/web exec tsc --noEmit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12d6f8820832e9e342af7711458fc)