### PR TITLE
fix(web): restore default memo template on book registration

### DIFF
--- a/apps/web/src/components/input/SearchBox/AddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/AddModal.tsx
@@ -50,6 +50,8 @@ interface Response {
   sheetName: string
 }
 
+const DEFAULT_MEMO = '[期待]\n\n[感想]\n'
+
 export const AddModal: React.FC = () => {
   const router = useRouter()
   const [open, setOpen] = useAtom(openAddModalAtom)
@@ -100,7 +102,7 @@ export const AddModal: React.FC = () => {
     setBook({
       ...item,
       isPublicMemo: false,
-      memo: item.memo ? item.memo : '[期待]\n\n[感想]\n',
+      memo: item.memo?.trim() ? item.memo : DEFAULT_MEMO,
       impression: '-',
       finished,
     })

--- a/apps/web/src/components/input/SearchBox/RegisterForm.tsx
+++ b/apps/web/src/components/input/SearchBox/RegisterForm.tsx
@@ -47,6 +47,8 @@ interface RegisterFormProps {
   onSuccess: (response: Response) => void
 }
 
+const DEFAULT_MEMO = '[期待]\n\n[感想]\n'
+
 export const RegisterForm: React.FC<RegisterFormProps> = ({
   item,
   onBack,
@@ -91,7 +93,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     setBook({
       ...item,
       isPublicMemo: false,
-      memo: item.memo ? item.memo : '[期待]\n\n[感想]\n',
+      memo: item.memo?.trim() ? item.memo : DEFAULT_MEMO,
       impression: '-',
       finished,
     })


### PR DESCRIPTION
### Motivation
- Registration flows could end up with an empty or whitespace-only memo so the default template `"[期待]\n\n[感想]\n"` must be restored when a memo is missing.

### Description
- Add a `DEFAULT_MEMO` constant and use `item.memo?.trim() ? item.memo : DEFAULT_MEMO` in both `RegisterForm` and `AddModal` so whitespace-only memos are replaced with the template and both registration UIs behave consistently.

### Testing
- Ran `pnpm -C apps/web lint`, which completed successfully with no new ESLint errors (existing warnings are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d996618a08832ea73667e7b384d984)