### PR TITLE
Add Rakuten cover-image fallback and improve Software Design ISBN handling

### DIFF
--- a/apps/web/src/utils/bookApi.ts
+++ b/apps/web/src/utils/bookApi.ts
@@ -29,6 +29,15 @@ const SEARCH_SOFTWARE_DESIGN_BY_ISBN = gql`
   }
 `
 
+const SEARCH_EXTERNAL_BOOKS_QUERY = gql`
+  query SearchExternalBooks($input: SearchExternalBooksInput!) {
+    searchExternalBooks(input: $input) {
+      id
+      image
+    }
+  }
+`
+
 /**
  * Software DesignのISBNかどうかを判定
  */
@@ -64,6 +73,37 @@ const searchSoftwareDesign = async (
   } catch (error) {
     console.error('Software Design search error:', error)
     return null
+  }
+}
+
+/**
+ * Rakuten Books(backend経由)でISBN検索して表紙画像を取得
+ */
+const searchRakutenBooksCover = async (
+  isbn: string
+): Promise<string | undefined> => {
+  try {
+    const isbn13 = isbn.length === 10 ? convertISBN10to13(isbn) : isbn
+    const { data } = await client.query({
+      query: SEARCH_EXTERNAL_BOOKS_QUERY,
+      variables: { input: { query: isbn13 } },
+      fetchPolicy: 'no-cache',
+    })
+
+    const items = data?.searchExternalBooks || []
+    const exactMatch = items.find((item: { id: string; image: string }) => {
+      return normalizeISBN(item.id || '') === isbn13
+    })
+    const fallback = items.find((item: { image: string }) => {
+      return !!item.image && item.image !== NO_IMAGE
+    })
+    const image = exactMatch?.image || fallback?.image
+
+    if (!image) return undefined
+    return image.replace('http:', 'https:')
+  } catch (error) {
+    console.error('Rakuten Books search error:', error)
+    return undefined
   }
 }
 
@@ -112,6 +152,7 @@ export const searchBookWithMultipleSources = async (
   isbn: string
 ): Promise<SearchResult | undefined> => {
   const normalizedISBN = normalizeISBN(isbn)
+  let rakutenCoverImage: string | undefined
 
   // 1. openBDで検索
   const openBDResult = await searchOpenBD(normalizedISBN)
@@ -123,20 +164,59 @@ export const searchBookWithMultipleSources = async (
         openBDResult.title
       )
       if (softwareDesignResult) {
+        if (!softwareDesignResult.image) {
+          rakutenCoverImage =
+            rakutenCoverImage || (await searchRakutenBooksCover(normalizedISBN))
+        }
         return {
           ...openBDResult,
-          image: softwareDesignResult.image,
+          image:
+            softwareDesignResult.image ||
+            rakutenCoverImage ||
+            openBDResult.image,
         }
       }
     }
-    return openBDResult
+
+    if (!openBDResult.image || openBDResult.image === NO_IMAGE) {
+      rakutenCoverImage =
+        rakutenCoverImage || (await searchRakutenBooksCover(normalizedISBN))
+    }
+    return {
+      ...openBDResult,
+      image:
+        openBDResult.image && openBDResult.image !== NO_IMAGE
+          ? openBDResult.image
+          : rakutenCoverImage || NO_IMAGE,
+    }
   }
 
   // 2. openBDで見つからない場合、Software DesignのISBNならタイトルなしで検索
   if (isSoftwareDesignISBN(normalizedISBN)) {
     const softwareDesignResult = await searchSoftwareDesign(normalizedISBN)
     if (softwareDesignResult) {
-      return softwareDesignResult
+      if (!softwareDesignResult.image) {
+        rakutenCoverImage =
+          rakutenCoverImage || (await searchRakutenBooksCover(normalizedISBN))
+      }
+      return {
+        ...softwareDesignResult,
+        image: softwareDesignResult.image || rakutenCoverImage || NO_IMAGE,
+      }
+    }
+  }
+
+  rakutenCoverImage =
+    rakutenCoverImage || (await searchRakutenBooksCover(normalizedISBN))
+  if (rakutenCoverImage) {
+    return {
+      id: normalizedISBN,
+      title: '不明なタイトル',
+      author: '著者不明',
+      category: '未分類',
+      image: rakutenCoverImage,
+      memo: '',
+      isbn: normalizedISBN,
     }
   }
 


### PR DESCRIPTION
### Motivation

- Provide a reliable cover image fallback when `openBD` or the Software Design source has no image by querying external books via the backend (Rakuten Books). 
- Improve handling for Software Design / 技術評論社 ISBNs so the specialized source is preferred but supplemented when image data is missing. 
- Normalize ISBNs and ensure returned cover URLs use `https`.

### Description

- Added `SEARCH_EXTERNAL_BOOKS_QUERY` GraphQL query and implemented `searchRakutenBooksCover` to query external book data and return a normalized `https` cover URL using `convertISBN10to13` when needed. 
- Updated `searchBookWithMultipleSources` to introduce a `rakutenCoverImage` fallback used across branches, including when `openBD` returns `NO_IMAGE`, when Software Design results lack an image, and to return a minimal `SearchResult` if only an external cover is found. 
- Ensured the external query uses `fetchPolicy: 'no-cache'` and that comparisons normalize ISBNs to find exact matches, with a fallback to any available non-placeholder image. 
- Added error handling and logging for the Rakuten search path and preserved existing prioritized lookup order (openBD -> Software Design -> external fallback).

### Testing

- Ran the TypeScript build/typecheck and it completed successfully (`yarn build` / `yarn typecheck`).
- Ran the linting suite and it passed (`yarn lint`).
- Ran the unit tests and they passed (`yarn test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9963034e0832e8009c276b23f08a2)