### PR TITLE
fix(web): preserve scroll position on back navigation

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,6 +3,9 @@ const path = require('path')
 
 const nextConfig = {
   swcMinify: true, // パフォーマンス改善のため有効化（framer-motion型エラーは修正済み）
+  experimental: {
+    scrollRestoration: true,
+  },
   images: {
     domains: [
       'books.google.com',


### PR DESCRIPTION
Enable Next.js experimental.scrollRestoration so the TOTAL page (and
other pages router routes) restore the previous scroll position when
returning from a book detail page via back navigation.