### PR TITLE
MarkdownEditor コンポーネントの初期コンテンツ読み込みの問題を修正しました

### DIFF
--- a/apps/web/src/components/input/MarkdownEditor.tsx
+++ b/apps/web/src/components/input/MarkdownEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useRef } from 'react'
 import {
   EditorRoot,
   EditorContent,
@@ -235,9 +235,9 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     []
   )
 
-  // 初期コンテンツ（マークダウン文字列をそのまま渡す）
-  // MarkdownExtensionがパースしてくれる
-  const initialContent = useMemo(() => value || '', [])
+  // 親の useEffect でセットされる初期値を onCreate 時点で拾うための ref（useMemoだと初回レンダリングの空文字を掴んだままになる）
+  const valueRef = useRef(value)
+  valueRef.current = value
 
   useEffect(() => {
     setMounted(true)
@@ -311,8 +311,9 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           className="rounded-lg border border-gray-200 bg-white shadow-sm"
           onCreate={({ editor }) => {
             // 初期値をマークダウンとしてセット
-            if (initialContent) {
-              editor.commands.setContent(initialContent)
+            const content = valueRef.current
+            if (content) {
+              editor.commands.setContent(content)
             }
           }}
           onUpdate={({ editor }) => {


### PR DESCRIPTION
## 概要

MarkdownEditor コンポーネントの初期コンテンツ読み込みの問題を修正しました。

親コンポーネントの `useEffect` で `value` が設定される場合、`useMemo` を使用した初期化では初回レンダリング時の空文字列を掴んだままになり、その後の `value` 更新が反映されていませんでした。

`useRef` を使用して常に最新の `value` を参照するように変更し、`onCreate` コールバック時点で正しい初期値を取得できるようにしました。

## 変更の種類

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## 詳細

**変更内容:**
- `useRef` を import に追加
- `initialContent` の `useMemo` を削除
- `valueRef` を新規作成し、毎回のレンダリングで最新の `value` を保持
- `onCreate` コールバック内で `valueRef.current` から初期値を取得

**理由:**
`useMemo` は依存配列が空のため、初回レンダリング時の値（通常は空文字列）をキャッシュしたままになります。親の `useEffect` で後から `value` が設定されても、`useMemo` の値は更新されないため、エディタの初期化時に古い値が使用されていました。`useRef` を使用することで、`onCreate` が呼ばれる時点で常に最新の `value` を参照できます。

## チェックリスト

- [ ] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01NaTRjZgDJQ5ZnUKrd9EEjC