### PR TITLE
feat(web): 本検索時のカテゴリを既存カテゴリに寄せて正規化

### DIFF
--- a/apps/web/src/components/input/SearchBox/RegisterForm.tsx
+++ b/apps/web/src/components/input/SearchBox/RegisterForm.tsx
@@ -18,6 +18,7 @@ import { MaskingHint } from '@/components/label/MaskingHint'
 import { getSheetsQuery } from '@/features/sheet/api'
 import { getBookCategoriesQuery } from '@/features/books/api'
 import { SearchResult } from '@/types/search'
+import { normalizeCategory } from '@/utils/category'
 
 const MarkdownEditor = dynamic(
   () =>
@@ -90,14 +91,33 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     setError('')
     if (!item) return
     const finished = dayjs().format('YYYY-MM-DD')
+    const existingCategories = categoriesData?.bookCategories
     setBook({
       ...item,
+      category: existingCategories?.length
+        ? normalizeCategory(item.category, existingCategories)
+        : item.category,
       isPublicMemo: false,
       memo: item.memo?.trim() ? item.memo : DEFAULT_MEMO,
       impression: '-',
       finished,
     })
+    // categoriesData を deps に含めるとメモ等の編集を上書きしうるため、到着後の再正規化は下の effect に任せる
   }, [item])
+
+  // categoriesData が遅れて到着した場合、未編集のカテゴリだけを既存カテゴリに寄せる
+  useEffect(() => {
+    if (!item) return
+    const existingCategories = categoriesData?.bookCategories
+    if (!existingCategories?.length) return
+    const normalized = normalizeCategory(item.category, existingCategories)
+    if (normalized === item.category) return
+    setBook((prev) => {
+      if (!prev) return prev
+      if (prev.category !== item.category) return prev
+      return { ...prev, category: normalized }
+    })
+  }, [item, categoriesData])
 
   const onClickAdd = async () => {
     if (!book) return

--- a/apps/web/src/utils/category.test.ts
+++ b/apps/web/src/utils/category.test.ts
@@ -1,0 +1,61 @@
+import { normalizeCategory } from './category'
+
+describe('normalizeCategory()', () => {
+  it('既存カテゴリが空の場合は取得カテゴリをそのまま返す', () => {
+    expect(normalizeCategory('人文・エッセイ', [])).toBe('人文・エッセイ')
+    expect(normalizeCategory('人文・エッセイ', null)).toBe('人文・エッセイ')
+    expect(normalizeCategory('人文・エッセイ', undefined)).toBe(
+      '人文・エッセイ'
+    )
+  })
+
+  it('取得カテゴリが空の場合は空文字を返す', () => {
+    expect(normalizeCategory('', ['エッセイ'])).toBe('')
+    expect(normalizeCategory(null, ['エッセイ'])).toBe('')
+    expect(normalizeCategory(undefined, ['エッセイ'])).toBe('')
+  })
+
+  it('完全一致する既存カテゴリがあればそれを返す', () => {
+    expect(normalizeCategory('エッセイ', ['小説', 'エッセイ'])).toBe('エッセイ')
+  })
+
+  it('「・」区切りで分割したトークンが既存カテゴリと一致すればそれを返す', () => {
+    expect(normalizeCategory('人文・エッセイ', ['エッセイ'])).toBe('エッセイ')
+    expect(normalizeCategory('ビジネス・経済・就職', ['技術書', '経済'])).toBe(
+      '経済'
+    )
+  })
+
+  it('括弧区切りのカテゴリも分割してマッチする', () => {
+    expect(normalizeCategory('漫画（コミック）', ['コミック'])).toBe('コミック')
+    expect(normalizeCategory('漫画（コミック）', ['漫画'])).toBe('漫画')
+  })
+
+  it('既存カテゴリ側が複合名でも取得カテゴリと一致すれば既存を返す', () => {
+    expect(normalizeCategory('エッセイ', ['人文・エッセイ'])).toBe(
+      '人文・エッセイ'
+    )
+  })
+
+  it('先頭に一致した既存カテゴリを返す（トークン順優先）', () => {
+    expect(normalizeCategory('人文・エッセイ', ['エッセイ', '人文'])).toBe(
+      '人文'
+    )
+  })
+
+  it('どの既存カテゴリともマッチしなければ取得カテゴリをそのまま返す', () => {
+    expect(normalizeCategory('医学・薬学', ['小説', 'エッセイ'])).toBe(
+      '医学・薬学'
+    )
+  })
+
+  it('前後空白をトリムしたうえでマッチ判定する', () => {
+    expect(normalizeCategory('  人文・エッセイ  ', ['エッセイ'])).toBe(
+      'エッセイ'
+    )
+  })
+
+  it('既存カテゴリに空文字が混ざっていても無視する', () => {
+    expect(normalizeCategory('エッセイ', ['', 'エッセイ'])).toBe('エッセイ')
+  })
+})

--- a/apps/web/src/utils/category.ts
+++ b/apps/web/src/utils/category.ts
@@ -1,0 +1,41 @@
+/**
+ * 検索で取得したカテゴリを既存カテゴリに寄せて正規化する。
+ * 例: 取得「人文・エッセイ」、既存に「エッセイ」があれば「エッセイ」を返す。
+ *
+ * マッチ判定は以下の順序で行う:
+ *   1. 完全一致
+ *   2. 取得カテゴリを区切り文字で分割したトークンが既存と完全一致
+ *   3. 既存カテゴリを区切り文字で分割したトークンが取得カテゴリと完全一致
+ * いずれにも当てはまらなければ取得カテゴリをそのまま返す。
+ */
+const SEPARATOR_REGEX = /[・／/（）()、，,]/
+
+const tokenize = (value: string): string[] =>
+  value
+    .split(SEPARATOR_REGEX)
+    .map((token) => token.trim())
+    .filter(Boolean)
+
+export const normalizeCategory = (
+  fetched: string | null | undefined,
+  existing: readonly string[] | null | undefined
+): string => {
+  if (!fetched) return fetched ?? ''
+  const trimmed = fetched.trim()
+  if (!existing || existing.length === 0) return trimmed
+
+  if (existing.includes(trimmed)) return trimmed
+
+  const fetchedTokens = tokenize(trimmed)
+  for (const token of fetchedTokens) {
+    if (existing.includes(token)) return token
+  }
+
+  for (const category of existing) {
+    if (!category) continue
+    const tokens = tokenize(category)
+    if (tokens.includes(trimmed)) return category
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
楽天Books API由来のカテゴリ（例: "人文・エッセイ"）をユーザーの既存
カテゴリ（例: "エッセイ"）にマッチさせて重複を防ぐ。RegisterForm で
カテゴリ初期値を設定する際に正規化を適用。