### PR TITLE
Persist and restore book registration drafts

### DIFF
--- a/apps/web/src/components/input/SearchBox/AddModal.tsx
+++ b/apps/web/src/components/input/SearchBox/AddModal.tsx
@@ -26,6 +26,11 @@ import { MaskingHint } from '@/components/label/MaskingHint'
 
 import { getSheetsQuery } from '@/features/sheet/api'
 import { getBookCategoriesQuery } from '@/features/books/api'
+import {
+  getBookRegistrationDraft,
+  removeBookRegistrationDraft,
+  saveBookRegistrationDraft,
+} from '@/utils/localStorage'
 
 // SSRを無効にしてクライアントサイドのみでロード
 const MarkdownEditor = dynamic(
@@ -68,6 +73,7 @@ export const AddModal: React.FC = () => {
   const [loading, setLoading] = useState(false)
   const [book, setBook] = useState(null)
   const [response, setResponse] = useState<Response>(null)
+  const [hasDraft, setHasDraft] = useState(false)
   const { reward, isAnimating } = useReward('rewardId', 'confetti', {
     elementCount: 200,
   })
@@ -91,13 +97,25 @@ export const AddModal: React.FC = () => {
 
   // シート取得次第、一番上のシートを選択状態にする
   useEffect(() => {
-    if (sheets.length === 0) return
+    if (sheets.length === 0 || sheet.id) return
     setSheet({ id: sheets[0].id, name: sheets[0].name })
-  }, [sheets])
+  }, [sheets, sheet.id])
 
   useEffect(() => {
     setResponse(null)
+    setHasDraft(false)
     if (!item) return
+
+    const draft = getBookRegistrationDraft()
+    if (draft?.item?.id === item.id) {
+      setBook(draft.book)
+      if (draft.sheet?.id) {
+        setSheet(draft.sheet)
+      }
+      setHasDraft(true)
+      return
+    }
+
     const finished = dayjs().format('YYYY-MM-DD')
     setBook({
       ...item,
@@ -107,6 +125,21 @@ export const AddModal: React.FC = () => {
       finished,
     })
   }, [item])
+
+  // 登録フォームの入力内容を自動保存して、モーダルを閉じても再開できるようにする
+  useEffect(() => {
+    if (!item || !book) return
+
+    const timeoutId = setTimeout(() => {
+      saveBookRegistrationDraft({
+        item,
+        book,
+        sheet,
+      })
+    }, 500)
+
+    return () => clearTimeout(timeoutId)
+  }, [item, book, sheet])
 
   const onClickAdd = async () => {
     if (!book) return
@@ -130,6 +163,7 @@ export const AddModal: React.FC = () => {
       })
     setResponse(res)
     if (res.result) {
+      removeBookRegistrationDraft()
       apolloClient.refetchQueries({ include: ['GetBooks'] })
       reward()
     }
@@ -178,6 +212,11 @@ export const AddModal: React.FC = () => {
           >
             <div className="flex h-full flex-col justify-between">
               <div className="bg-white p-4">
+                {hasDraft && (
+                  <div className="mb-3 rounded-md bg-blue-50 p-3 text-sm text-blue-800">
+                    💾 前回入力中だった内容を復元しました
+                  </div>
+                )}
                 <div className="mb-2 flex items-center">
                   <ImagePicker
                     img={book?.image}

--- a/apps/web/src/components/input/SearchBox/RegisterForm.tsx
+++ b/apps/web/src/components/input/SearchBox/RegisterForm.tsx
@@ -19,6 +19,11 @@ import { getSheetsQuery } from '@/features/sheet/api'
 import { getBookCategoriesQuery } from '@/features/books/api'
 import { SearchResult } from '@/types/search'
 import { normalizeCategory } from '@/utils/category'
+import {
+  getBookRegistrationDraft,
+  removeBookRegistrationDraft,
+  saveBookRegistrationDraft,
+} from '@/utils/localStorage'
 
 const MarkdownEditor = dynamic(
   () =>
@@ -65,6 +70,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
   const [loading, setLoading] = useState(false)
   const [book, setBook] = useState(null)
   const [error, setError] = useState('')
+  const [hasDraft, setHasDraft] = useState(false)
   const [sheet, setSheet] = useState<{ id: number; name: string }>({
     id: null,
     name: null,
@@ -83,13 +89,25 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     : []
 
   useEffect(() => {
-    if (sheets.length === 0) return
+    if (sheets.length === 0 || sheet.id) return
     setSheet({ id: sheets[0].id, name: sheets[0].name })
-  }, [sheets])
+  }, [sheets, sheet.id])
 
   useEffect(() => {
     setError('')
+    setHasDraft(false)
     if (!item) return
+
+    const draft = getBookRegistrationDraft()
+    if (draft?.item?.id === item.id) {
+      setBook(draft.book)
+      if (draft.sheet?.id) {
+        setSheet(draft.sheet)
+      }
+      setHasDraft(true)
+      return
+    }
+
     const finished = dayjs().format('YYYY-MM-DD')
     const existingCategories = categoriesData?.bookCategories
     setBook({
@@ -119,6 +137,21 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     })
   }, [item, categoriesData])
 
+  // 登録フォームの入力内容を自動保存して、モーダルを閉じても再開できるようにする
+  useEffect(() => {
+    if (!item || !book) return
+
+    const timeoutId = setTimeout(() => {
+      saveBookRegistrationDraft({
+        item,
+        book,
+        sheet,
+      })
+    }, 500)
+
+    return () => clearTimeout(timeoutId)
+  }, [item, book, sheet])
+
   const onClickAdd = async () => {
     if (!book) return
     setLoading(true)
@@ -141,6 +174,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
         }
       })
     if (res.result) {
+      removeBookRegistrationDraft()
       apolloClient.refetchQueries({ include: ['GetBooks'] })
       onSuccess(res)
     } else {
@@ -154,7 +188,10 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
       {/* ヘッダー: 戻るボタン */}
       <div className="flex shrink-0 items-center border-b border-gray-100 px-4 py-3">
         <button
-          onClick={onBack}
+          onClick={() => {
+            removeBookRegistrationDraft()
+            onBack()
+          }}
           className="mr-3 rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
         >
           <IoArrowBack size={20} />
@@ -164,6 +201,11 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
 
       {/* フォーム本体 */}
       <div className="flex-1 overflow-y-auto bg-white p-4">
+        {hasDraft && (
+          <div className="mb-3 rounded-md bg-blue-50 p-3 text-sm text-blue-800">
+            💾 前回入力中だった内容を復元しました
+          </div>
+        )}
         <div className="mb-2 flex items-center">
           <ImagePicker
             img={book?.image}

--- a/apps/web/src/components/input/SearchBox/SearchModal.tsx
+++ b/apps/web/src/components/input/SearchBox/SearchModal.tsx
@@ -14,6 +14,10 @@ import { ISBNSearchResult } from './ISBNSearchResult'
 import { RegisterForm } from './RegisterForm'
 import { SuccessView } from './SuccessView'
 import { SearchResult } from '@/types/search'
+import {
+  getBookRegistrationDraft,
+  removeBookRegistrationDraft,
+} from '@/utils/localStorage'
 
 /**
  * 入力がISBN形式かどうかを判定する
@@ -56,6 +60,18 @@ export const SearchModal: React.FC = () => {
     }
   }, [open, showCamera, view])
 
+  // 入力途中の登録下書きがあれば、モーダルを開いたタイミングで登録フォームから再開する
+  useEffect(() => {
+    if (!open) return
+
+    const draft = getBookRegistrationDraft()
+    if (!draft) return
+
+    setSelectedBook(draft.item)
+    setInputValue(draft.item.title || '')
+    setView('register')
+  }, [open])
+
   // モーダルが閉じたらリセット
   useEffect(() => {
     if (!open) {
@@ -88,6 +104,7 @@ export const SearchModal: React.FC = () => {
   }
 
   const handleBack = () => {
+    removeBookRegistrationDraft()
     setView('search')
     setSelectedBook(null)
   }

--- a/apps/web/src/utils/localStorage.ts
+++ b/apps/web/src/utils/localStorage.ts
@@ -1,8 +1,11 @@
+import type { SearchResult } from '@/types/search'
+
 /**
  * ローカルストレージのキー定義
  */
 const STORAGE_KEYS = {
   BOOK_DRAFT: 'kidoku_book_draft',
+  BOOK_REGISTRATION_DRAFT: 'kidoku_book_registration_draft',
 } as const
 
 /**
@@ -17,6 +20,23 @@ export interface BookDraftData {
   title?: string
   author?: string
   isPublicMemo?: boolean
+  timestamp: number // 保存日時
+}
+
+/**
+ * 書籍登録中の下書きデータ型
+ */
+export interface BookRegistrationDraftData {
+  item: SearchResult
+  book: SearchResult & {
+    impression?: string
+    finished?: string
+    isPublicMemo?: boolean
+  }
+  sheet?: {
+    id: number
+    name: string
+  }
   timestamp: number // 保存日時
 }
 
@@ -127,5 +147,74 @@ export const cleanupOldDrafts = (): void => {
     }
   } catch (error) {
     console.error('Failed to cleanup old drafts:', error)
+  }
+}
+
+/**
+ * ローカルストレージから書籍登録フォームの下書きデータを取得
+ */
+export const getBookRegistrationDraft =
+  (): BookRegistrationDraftData | null => {
+    if (typeof window === 'undefined') return null
+
+    try {
+      const data = localStorage.getItem(STORAGE_KEYS.BOOK_REGISTRATION_DRAFT)
+      if (!data) return null
+
+      const draft: BookRegistrationDraftData = JSON.parse(data)
+
+      // 24時間以上経過した下書きは削除
+      if (draft && Date.now() - draft.timestamp > 24 * 60 * 60 * 1000) {
+        removeBookRegistrationDraft()
+        return null
+      }
+
+      return draft || null
+    } catch (error) {
+      console.error(
+        'Failed to get book registration draft from localStorage:',
+        error
+      )
+      return null
+    }
+  }
+
+/**
+ * ローカルストレージに書籍登録フォームの下書きデータを保存
+ */
+export const saveBookRegistrationDraft = (
+  draftData: Omit<BookRegistrationDraftData, 'timestamp'>
+): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(
+      STORAGE_KEYS.BOOK_REGISTRATION_DRAFT,
+      JSON.stringify({
+        ...draftData,
+        timestamp: Date.now(),
+      })
+    )
+  } catch (error) {
+    console.error(
+      'Failed to save book registration draft to localStorage:',
+      error
+    )
+  }
+}
+
+/**
+ * ローカルストレージから書籍登録フォームの下書きデータを削除
+ */
+export const removeBookRegistrationDraft = (): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEYS.BOOK_REGISTRATION_DRAFT)
+  } catch (error) {
+    console.error(
+      'Failed to remove book registration draft from localStorage:',
+      error
+    )
   }
 }


### PR DESCRIPTION
### Motivation
- Allow users to resume an in-progress book registration when the modal is closed accidentally or navigated away, so input is not lost.
- Support both the new registration flow and the legacy add-modal flow with the same draft persistence behavior.

### Description
- Add `BOOK_REGISTRATION_DRAFT` support and types (`BookRegistrationDraftData`) plus helpers `getBookRegistrationDraft`, `saveBookRegistrationDraft`, and `removeBookRegistrationDraft` in `apps/web/src/utils/localStorage.ts` with 24-hour expiry.
- Restore an in-progress registration when the search modal opens by reading the registration draft and switching directly to the registration view in `SearchModal` and clear the draft on explicit back navigation.
- Auto-save registration form fields and selected sheet (500ms debounce), show a restore notice when a draft is loaded, and clear the draft on successful submit in `RegisterForm` and the legacy `AddModal`.
- Avoid overwriting an already-selected sheet when initializing defaults by guarding with `sheet.id` in both `RegisterForm` and `AddModal`.

### Testing
- Ran `pnpm --filter web check-types` and the TypeScript checks completed successfully.
- Ran `pnpm --filter web lint` and ESLint completed successfully (there are unrelated existing warnings in the codebase).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260d1c2324832eb09ae1b7073fdb8f)