### PR TITLE
feat: 本登録モーダルの入力内容をローカルストレージにキャッシュして再開可能にする

### DIFF
--- a/apps/web/src/components/input/SearchBox/RegisterForm.tsx
+++ b/apps/web/src/components/input/SearchBox/RegisterForm.tsx
@@ -19,6 +19,11 @@ import { getSheetsQuery } from '@/features/sheet/api'
 import { getBookCategoriesQuery } from '@/features/books/api'
 import { SearchResult } from '@/types/search'
 import { normalizeCategory } from '@/utils/category'
+import {
+  getBookRegisterDraft,
+  saveBookRegisterDraft,
+  removeBookRegisterDraft,
+} from '@/utils/localStorage'
 
 const MarkdownEditor = dynamic(
   () =>
@@ -70,6 +75,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     name: null,
   })
   const [openAdd, setOpenAdd] = useState(false)
+  const [hasDraft, setHasDraft] = useState(false)
 
   const { data: categoriesData } = useQuery<{ bookCategories: string[] }>(
     getBookCategoriesQuery,
@@ -84,12 +90,26 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
 
   useEffect(() => {
     if (sheets.length === 0) return
-    setSheet({ id: sheets[0].id, name: sheets[0].name })
+    // 下書きからシートを復元済みの場合は上書きしない
+    setSheet((prev) =>
+      prev.id ? prev : { id: sheets[0].id, name: sheets[0].name }
+    )
   }, [sheets])
 
   useEffect(() => {
     setError('')
     if (!item) return
+
+    // 同じ本の入力中下書きが残っていれば復元する
+    const draft = getBookRegisterDraft()
+    if (draft?.book && String(draft.item?.id) === String(item.id)) {
+      setBook(draft.book)
+      if (draft.sheet) setSheet(draft.sheet)
+      setHasDraft(true)
+      return
+    }
+
+    setHasDraft(false)
     const finished = dayjs().format('YYYY-MM-DD')
     const existingCategories = categoriesData?.bookCategories
     setBook({
@@ -105,6 +125,16 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
     // categoriesData を deps に含めるとメモ等の編集を上書きしうるため、到着後の再正規化は下の effect に任せる
   }, [item])
 
+  // 入力内容をローカルストレージに自動保存（500msデバウンス）
+  // モーダルを誤って閉じても、再度開いたときに続きから再開できるようにする
+  useEffect(() => {
+    if (!item || !book) return
+    const timeoutId = setTimeout(() => {
+      saveBookRegisterDraft({ item, book, sheet })
+    }, 500)
+    return () => clearTimeout(timeoutId)
+  }, [item, book, sheet])
+
   // categoriesData が遅れて到着した場合、未編集のカテゴリだけを既存カテゴリに寄せる
   useEffect(() => {
     if (!item) return
@@ -118,6 +148,25 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
       return { ...prev, category: normalized }
     })
   }, [item, categoriesData])
+
+  // 復元した下書きを破棄し、選択した本の初期値に戻す
+  const onClearDraft = () => {
+    if (!item) return
+    removeBookRegisterDraft()
+    setHasDraft(false)
+    const finished = dayjs().format('YYYY-MM-DD')
+    const existingCategories = categoriesData?.bookCategories
+    setBook({
+      ...item,
+      category: existingCategories?.length
+        ? normalizeCategory(item.category, existingCategories)
+        : item.category,
+      isPublicMemo: false,
+      memo: item.memo?.trim() ? item.memo : DEFAULT_MEMO,
+      impression: '-',
+      finished,
+    })
+  }
 
   const onClickAdd = async () => {
     if (!book) return
@@ -141,6 +190,8 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
         }
       })
     if (res.result) {
+      removeBookRegisterDraft()
+      setHasDraft(false)
       apolloClient.refetchQueries({ include: ['GetBooks'] })
       onSuccess(res)
     } else {
@@ -160,6 +211,19 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
           <IoArrowBack size={20} />
         </button>
         <h2 className="text-sm font-bold text-gray-700">本を登録</h2>
+        {hasDraft && (
+          <div className="ml-auto flex items-center gap-2">
+            <span className="text-xs text-gray-400">
+              入力内容を復元しました
+            </span>
+            <button
+              onClick={onClearDraft}
+              className="rounded-md px-2 py-1 text-xs text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+            >
+              クリア
+            </button>
+          </div>
+        )}
       </div>
 
       {/* フォーム本体 */}

--- a/apps/web/src/components/input/SearchBox/SearchModal.tsx
+++ b/apps/web/src/components/input/SearchBox/SearchModal.tsx
@@ -14,6 +14,7 @@ import { ISBNSearchResult } from './ISBNSearchResult'
 import { RegisterForm } from './RegisterForm'
 import { SuccessView } from './SuccessView'
 import { SearchResult } from '@/types/search'
+import { getBookRegisterDraft } from '@/utils/localStorage'
 
 /**
  * 入力がISBN形式かどうかを判定する
@@ -48,6 +49,16 @@ export const SearchModal: React.FC = () => {
   const [successData, setSuccessData] = useState<SuccessData | null>(null)
   const { data: session } = useSession()
   const router = useRouter()
+
+  // モーダルを開いたとき、入力中の下書きが残っていれば登録ビューから再開する
+  useEffect(() => {
+    if (!open) return
+    const draft = getBookRegisterDraft()
+    if (draft?.item) {
+      setSelectedBook(draft.item)
+      setView('register')
+    }
+  }, [open])
 
   // モーダル開いたら自動でinputフィールドにフォーカスする（検索ビュー、カメラモード以外）
   useEffect(() => {

--- a/apps/web/src/utils/localStorage.ts
+++ b/apps/web/src/utils/localStorage.ts
@@ -1,8 +1,11 @@
+import type { SearchResult } from '@/types/search'
+
 /**
  * ローカルストレージのキー定義
  */
 const STORAGE_KEYS = {
   BOOK_DRAFT: 'kidoku_book_draft',
+  BOOK_REGISTER_DRAFT: 'kidoku_book_register_draft',
 } as const
 
 /**
@@ -127,5 +130,80 @@ export const cleanupOldDrafts = (): void => {
     }
   } catch (error) {
     console.error('Failed to cleanup old drafts:', error)
+  }
+}
+
+/**
+ * 本登録モーダルの入力中データ型
+ *
+ * 既存本の編集（BookDraftData）とは異なり、まだDBに登録されていない本のための
+ * 下書き。登録フローは同時に1冊しか進行しないため、bookIdではなく単一スロットで保持する。
+ */
+export interface BookRegisterDraftData {
+  /** 選択中の検索結果（登録ビューを復元するために保持） */
+  item: SearchResult
+  /** フォームの入力値 */
+  book: Record<string, unknown>
+  /** 保存先シート */
+  sheet?: { id: number | null; name: string | null }
+  timestamp: number // 保存日時
+}
+
+/**
+ * ローカルストレージから本登録の下書きデータを取得
+ */
+export const getBookRegisterDraft = (): BookRegisterDraftData | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const data = localStorage.getItem(STORAGE_KEYS.BOOK_REGISTER_DRAFT)
+    if (!data) return null
+
+    const draft: BookRegisterDraftData = JSON.parse(data)
+
+    // 24時間以上経過した下書きは削除
+    if (draft && Date.now() - draft.timestamp > 24 * 60 * 60 * 1000) {
+      removeBookRegisterDraft()
+      return null
+    }
+
+    return draft || null
+  } catch (error) {
+    console.error('Failed to get book register draft from localStorage:', error)
+    return null
+  }
+}
+
+/**
+ * ローカルストレージに本登録の下書きデータを保存
+ */
+export const saveBookRegisterDraft = (
+  draft: Omit<BookRegisterDraftData, 'timestamp'>
+): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(
+      STORAGE_KEYS.BOOK_REGISTER_DRAFT,
+      JSON.stringify({ ...draft, timestamp: Date.now() })
+    )
+  } catch (error) {
+    console.error('Failed to save book register draft to localStorage:', error)
+  }
+}
+
+/**
+ * ローカルストレージから本登録の下書きデータを削除
+ */
+export const removeBookRegisterDraft = (): void => {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(STORAGE_KEYS.BOOK_REGISTER_DRAFT)
+  } catch (error) {
+    console.error(
+      'Failed to remove book register draft from localStorage:',
+      error
+    )
   }
 }


### PR DESCRIPTION
モーダルを誤って閉じても、再度開いたときに入力途中のフォーム内容
（タイトル・著者・カテゴリ・感想・読了日・メモ・公開設定・保存先シート）
を復元して登録を再開できるようにした。

- localStorage.ts に登録下書き用の get/save/remove を追加（24時間で失効）
- RegisterForm: 500msデバウンスで自動保存、同一の本なら復元、登録成功時に削除
- RegisterForm: 復元時は「クリア」ボタンで破棄して新規入力に戻せる
- SearchModal: モーダルを開いたとき下書きがあれば登録ビューから再開