### PR TITLE
Fix ISR permanent 404 caching by adding revalidate to notFound responses

### DIFF
--- a/apps/web/src/pages/books/[bookId].tsx
+++ b/apps/web/src/pages/books/[bookId].tsx
@@ -44,8 +44,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     })
 
     if (!book) {
+      // notFoundをrevalidateなしで返すとISRが404を恒久的にキャッシュしてしまう。
+      // 作成直後でまだ参照できないケースに備え、revalidateを付与して自己回復させる。
       return {
         notFound: true,
+        revalidate: 10,
       }
     }
 
@@ -79,8 +82,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     }
   } catch (error) {
     console.error('Error fetching book:', error)
+    // 一時的なDBエラー等で404を恒久キャッシュしないよう、revalidateを付与する。
     return {
       notFound: true,
+      revalidate: 10,
     }
   }
 }


### PR DESCRIPTION
## 概要

書籍詳細ページ（`[bookId].tsx`）の `getStaticProps` で `notFound: true` を返す際に `revalidate: 10` を追加しました。

ISR（Incremental Static Regeneration）では `notFound: true` を `revalidate` なしで返すと、404ページが恒久的にキャッシュされてしまいます。以下の2つのケースで問題が発生していました：

1. **書籍作成直後のアクセス**: 書籍がDBに存在しないため404になるが、その後書籍が参照可能になっても恒久的に404のままになる
2. **一時的なDBエラー**: 一時的なDB接続エラーで404を返すと、その後DBが復旧しても恒久的に404のままになる

`revalidate: 10` を付与することで、10秒後に自動的にページを再生成し、自己回復できるようにしました。

## 変更の種類

- [x] Bug fix

## チェックリスト

- [x] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01XhpU4qEEqhMv5kpFkBB8MP