### PR TITLE
Add GitHub Actions workflow for database schema push

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -1,0 +1,46 @@
+name: DB Push
+
+on:
+  workflow_dispatch:
+    inputs:
+      accept_data_loss:
+        description: 'データ損失を許容して push する（--accept-data-loss）'
+        required: false
+        default: false
+        type: boolean
+
+# 同時に複数の db push が走らないように直列化する
+concurrency:
+  group: db-push
+  cancel-in-progress: false
+
+jobs:
+  db-push:
+    runs-on: ubuntu-latest
+    # DATABASE_URL などの保護されたシークレットを使うため Production environment を指定
+    environment: Production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma clients
+        run: |
+          pnpm --filter web exec prisma generate
+          pnpm --filter api exec prisma generate
+
+      - name: Push schema to database
+        run: |
+          ARGS="--skip-generate"
+          if [ "${{ inputs.accept_data_loss }}" = "true" ]; then
+            ARGS="$ARGS --accept-data-loss"
+          fi
+          echo "prisma db push $ARGS"
+          pnpm --filter web db:push -- $ARGS
+          pnpm --filter api db:push -- $ARGS
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "analyze": "ANALYZE=true next build",
     "lighthouse": "lighthouse http://localhost:3000",
     "prisma:generate": "prisma generate",
+    "db:push": "prisma db push",
     "prisma:pull": "prisma db pull",
     "prisma:format": "prisma format",
     "deploy": "fly deploy --local-only",


### PR DESCRIPTION
## 概要

Prismaスキーマの変更をデータベースに反映するためのGitHub Actionsワークフロー（`db-push`）を追加しました。手動トリガー（`workflow_dispatch`）で実行でき、必要に応じてデータ損失を許容するオプション（`--accept-data-loss`）を指定できます。

## 変更の種類

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## 変更内容

### `.github/workflows/db-push.yml` (新規追加)
- **手動トリガー**: `workflow_dispatch`で実行可能
- **入力パラメータ**: `accept_data_loss` boolean フラグ（デフォルト: false）
- **並行実行制御**: 同時に複数の db push が走らないよう直列化（`concurrency.cancel-in-progress: false`）
- **環境**: Production environment を指定し、`DATABASE_URL` などの保護されたシークレットにアクセス可能
- **処理内容**:
  1. リポジトリをチェックアウト
  2. pnpm + Node.js をセットアップ
  3. 依存関係をインストール
  4. Web/API 両方の Prisma クライアントを生成
  5. Web/API 両方に対して `prisma db push` を実行（`--accept-data-loss` フラグは入力値に応じて付与）

### `apps/web/package.json` (修正)
- `db:push` スクリプトを追加: `prisma db push`

## チェックリスト

- [x] `pnpm validate` が通ること
- [x] Prisma スキーマ変更時: Web/API 両方を更新した（スクリプト追加のみ）
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した（該当なし）
- [ ] 必要に応じてテストを追加・更新した（CI/CD設定のため不要）

## 補足

このワークフローにより、Prismaスキーマ変更後の `db push` 操作をGitHub UIから安全に実行できるようになります。Web/API 両方のスキーマを同期する際に活用できます。

https://claude.ai/code/session_01EbZb9YxRQP1PLTXNTo75Ng