### PR TITLE
Prevent duplicate notifications for book-related actions

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -168,6 +168,7 @@ model Notification {
   user    User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
   actor   User     @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, actorId, type, bookId], map: "uniq_user_actor_type_book")
   @@index([userId])
   @@index([actorId])
   @@map("notifications")

--- a/apps/api/src/infrastructure/repositories/notification.spec.ts
+++ b/apps/api/src/infrastructure/repositories/notification.spec.ts
@@ -1,0 +1,87 @@
+import { NotificationRepository } from './notification';
+import { PrismaService } from '../database/prisma.service';
+
+describe('NotificationRepository', () => {
+  let repository: NotificationRepository;
+  let prisma: {
+    notification: {
+      upsert: jest.Mock;
+      create: jest.Mock;
+    };
+  };
+
+  beforeEach(() => {
+    prisma = {
+      notification: {
+        upsert: jest.fn(),
+        create: jest.fn(),
+      },
+    };
+    repository = new NotificationRepository(prisma as unknown as PrismaService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('自分自身の操作では通知を作成しない', async () => {
+    await repository.create({
+      userId: 'same',
+      actorId: 'same',
+      type: 'like',
+      bookId: 1,
+    });
+
+    expect(prisma.notification.upsert).not.toHaveBeenCalled();
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('いいね通知は (受信者・操作者・種別・本) で upsert し重複作成しない', async () => {
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    jest.useFakeTimers().setSystemTime(now);
+
+    await repository.create({
+      userId: 'owner',
+      actorId: 'liker',
+      type: 'like',
+      bookId: 1,
+    });
+
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+    expect(prisma.notification.upsert).toHaveBeenCalledWith({
+      where: {
+        userId_actorId_type_bookId: {
+          userId: 'owner',
+          actorId: 'liker',
+          type: 'like',
+          bookId: 1,
+        },
+      },
+      create: {
+        userId: 'owner',
+        actorId: 'liker',
+        type: 'like',
+        bookId: 1,
+      },
+      update: { read: false, created: now },
+    });
+  });
+
+  it('本に紐づかない通知（フォロー等）は通常作成する', async () => {
+    await repository.create({
+      userId: 'followed',
+      actorId: 'follower',
+      type: 'follow',
+    });
+
+    expect(prisma.notification.upsert).not.toHaveBeenCalled();
+    expect(prisma.notification.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'followed',
+        actorId: 'follower',
+        type: 'follow',
+        bookId: null,
+      },
+    });
+  });
+});

--- a/apps/api/src/infrastructure/repositories/notification.ts
+++ b/apps/api/src/infrastructure/repositories/notification.ts
@@ -14,13 +14,26 @@ export class NotificationRepository implements INotificationRepository {
   async create(params: CreateNotificationParams): Promise<void> {
     // 自分自身の操作では通知しない
     if (params.userId === params.actorId) return;
+
+    const { userId, actorId, type } = params;
+
+    // 本に紐づく通知（いいね等）は (受信者・操作者・種別・本) ごとに1件に集約する。
+    // いいね→いいね解除→再いいねを繰り返しても通知が重複作成されないようにし、
+    // 再操作時は既存通知を最新化（未読に戻す）する。
+    if (params.bookId != null) {
+      const bookId = params.bookId;
+      await this.prisma.notification.upsert({
+        where: {
+          userId_actorId_type_bookId: { userId, actorId, type, bookId },
+        },
+        create: { userId, actorId, type, bookId },
+        update: { read: false, created: new Date() },
+      });
+      return;
+    }
+
     await this.prisma.notification.create({
-      data: {
-        userId: params.userId,
-        actorId: params.actorId,
-        type: params.type,
-        bookId: params.bookId ?? null,
-      },
+      data: { userId, actorId, type, bookId: null },
     });
   }
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -168,6 +168,7 @@ model Notification {
   user    User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
   actor   User     @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, actorId, type, bookId], map: "uniq_user_actor_type_book")
   @@index([userId])
   @@index([actorId])
   @@map("notifications")


### PR DESCRIPTION
## 概要

通知システムを改善し、いいね等の本に紐づく通知が重複作成されないようにしました。同じユーザーが同じ本に対して何度も同じアクション（いいね→いいね解除→再いいね等）を繰り返した場合、通知は1件に集約され、再操作時は既存通知を最新化（未読に戻す）するようになります。

### 変更内容

1. **Prismaスキーマ更新**: `Notification`モデルに複合ユニーク制約を追加
   - `(userId, actorId, type, bookId)` の組み合わせで一意性を保証
   - 本に紐づかない通知（フォロー等）は複数作成可能（`bookId`がNULLのため制約外）

2. **NotificationRepository実装**: 本に紐づく通知の処理を分岐
   - `bookId != null`: `upsert`で重複を防止し、再操作時は`read: false`と`created`を更新
   - `bookId == null`: 従来通り`create`で新規作成（フォロー等は重複作成可能）

3. **テスト追加**: 3つのテストケースで動作を検証
   - 自分自身の操作では通知を作成しない
   - いいね通知は`(受信者・操作者・種別・本)`で集約される
   - 本に紐づかない通知は通常作成される

## 変更の種類

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## チェックリスト

- [x] `pnpm validate` が通ること
- [x] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [x] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01HjUwBeMdtUrY8AHChVUpHS