### PR TITLE
Prevent liking own books and hide like button on own books

### DIFF
--- a/apps/api/src/infrastructure/repositories/like.ts
+++ b/apps/api/src/infrastructure/repositories/like.ts
@@ -16,6 +16,11 @@ export class LikeRepository implements ILikeRepository {
     });
     if (!book) return { created: false, bookOwnerId: null };
 
+    // 自分の本にはいいねできない
+    if (book.userId === userId) {
+      return { created: false, bookOwnerId: book.userId };
+    }
+
     const existing = await this.prisma.like.findUnique({
       where: { userId_bookId: { userId, bookId } },
     });

--- a/apps/web/src/features/social/components/DiscoverPage.tsx
+++ b/apps/web/src/features/social/components/DiscoverPage.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { useQuery } from '@apollo/client'
 import { NextSeo } from 'next-seo'
+import { FaRegHeart } from 'react-icons/fa'
 import { Container } from '@/components/layout/Container'
 import { TitleWithLine } from '@/components/label/TitleWithLine'
 import { useCachedSession } from '@/hooks/useCachedSession'
@@ -43,8 +44,9 @@ interface FeedBook {
 }
 
 export const DiscoverPage: React.FC = () => {
-  const { status } = useCachedSession()
+  const { session, status } = useCachedSession()
   const isAuthed = status === 'authenticated'
+  const currentUsername = session?.user?.name ?? null
 
   const { data: popularData } = useQuery(popularBooksQuery, {
     variables: { limit: 12 },
@@ -88,6 +90,7 @@ export const DiscoverPage: React.FC = () => {
                 sheet={book.sheet}
                 likeCount={book.likeCount}
                 liked={likedSet.has(Number(book.id))}
+                isMine={!!currentUsername && book.username === currentUsername}
               />
             ))}
           </div>
@@ -112,6 +115,7 @@ export const DiscoverPage: React.FC = () => {
                 sheet={book.sheet}
                 likeCount={book.likeCount}
                 liked={likedSet.has(Number(book.id))}
+                isMine={!!currentUsername && book.username === currentUsername}
               />
             ))}
           </div>
@@ -165,6 +169,8 @@ interface BookCardProps {
   sheet: string
   likeCount: number
   liked: boolean
+  /** 自分の本かどうか（自分の本にはいいねボタンを表示しない） */
+  isMine?: boolean
 }
 
 const BookCard: React.FC<BookCardProps> = ({
@@ -175,6 +181,7 @@ const BookCard: React.FC<BookCardProps> = ({
   sheet,
   likeCount,
   liked,
+  isMine = false,
 }) => (
   <div className="flex flex-col">
     <Link href={`/books/${id}`} className="mb-2">
@@ -193,7 +200,14 @@ const BookCard: React.FC<BookCardProps> = ({
       >
         {username}
       </Link>
-      <LikeButton bookId={id} count={likeCount} liked={liked} size={16} />
+      {isMine ? (
+        <span className="flex items-center gap-1 text-sm text-gray-400">
+          <FaRegHeart size={16} />
+          <span className="tabular-nums">{likeCount}</span>
+        </span>
+      ) : (
+        <LikeButton bookId={id} count={likeCount} liked={liked} size={16} />
+      )}
     </div>
   </div>
 )


### PR DESCRIPTION
## 概要

ユーザーが自分の本に対していいねできないようにする機能を実装しました。

### 変更内容

**バックエンド（API）**
- `LikeRepository.create()` に自分の本へのいいね防止ロジックを追加
- 本の所有者とログインユーザーが同じ場合、いいねの作成を拒否

**フロントエンド（Web）**
- `DiscoverPage` で現在のユーザー名を取得し、各書籍カードに `isMine` プロップを渡すように修正
- `BookCard` コンポーネントで自分の本の場合、いいねボタンの代わりにいいね数を表示のみ（ハート アイコン + 数字）
- 自分の本でない場合は従来通りいいねボタンを表示

## 変更の種類

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## チェックリスト

- [ ] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01Dn3WSwtPSjTzf8KSti9mW7