### PR TITLE
feat: Suiブロックチェーン決済に対応

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,3 +18,15 @@ RAKUTEN_ACCESS_KEY=
 
 # Admin API Key (管理者用APIキー認証、リインデックスなどの管理操作に使用)
 ADMIN_API_KEY=your-secure-admin-api-key
+
+# Sui 決済（ブロックチェーン決済の検証に使用）
+# 検証対象ネットワーク: mainnet | testnet | devnet | localnet
+SUI_NETWORK=testnet
+# 送金先（受取）アドレス
+SUI_RECIPIENT_ADDRESS=
+# 必要な金額（MIST 単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI）
+SUI_PAYMENT_AMOUNT_MIST=10000000
+# 任意: フルノードURLを上書きする場合に設定
+SUI_FULLNODE_URL=
+# 'false' でオンチェーン検証をスキップ（外部ネットワーク非対応のプレビュー/サンドボックス用）
+SUI_PAYMENT_VERIFY=true

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,8 +22,7 @@ ADMIN_API_KEY=your-secure-admin-api-key
 # Sui 決済（ブロックチェーン決済の検証に使用）
 # 検証対象ネットワーク: mainnet | testnet | devnet | localnet
 SUI_NETWORK=testnet
-# 送金先（受取）アドレス
-SUI_RECIPIENT_ADDRESS=
+# ※ 送金先は本の所有者がDBに登録した受取アドレスを使用するためグローバル設定は不要
 # 必要な金額（MIST 単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI）
 SUI_PAYMENT_AMOUNT_MIST=10000000
 # 任意: フルノードURLを上書きする場合に設定

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@apollo/server": "^5.4.0",
     "@as-integrations/express5": "^1.1.2",
+    "@mysten/sui": "^1.18.0",
     "@prisma/client": "^5.2.0",
     "@nestjs/apollo": "^13.1.0",
     "@nestjs/common": "^11.0.1",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -79,6 +79,7 @@ model User {
   emailVerified    DateTime?        @map("email_verified")
   image            String?
   admin            Boolean          @default(false)
+  suiAddress       String?          @map("sui_address") @db.VarChar(80)
   accounts         Account[]
   sessions         Session[]
   sheets           sheets[]

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -40,6 +40,7 @@ model books {
   user             User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   yearly_top_books YearlyTopBook[]
   likes            Like[]
+  purchases        Purchase[]
 }
 
 model Account {
@@ -90,6 +91,7 @@ model User {
   likes              Like[]
   notifications      Notification[] @relation("notificationUser")
   actorNotifications Notification[] @relation("notificationActor")
+  purchases          Purchase[]
 
   @@map("users")
 }
@@ -155,6 +157,24 @@ model Like {
   @@unique([userId, bookId], map: "uniq_user_book")
   @@index([bookId])
   @@map("likes")
+}
+
+model Purchase {
+  id               Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId           String   @map("user_id")
+  bookId           Int      @map("book_id")
+  txDigest         String   @unique @map("tx_digest") @db.VarChar(120)
+  network          String   @default("testnet") @db.VarChar(20)
+  amount           String   @db.VarChar(40)
+  senderAddress    String   @map("sender_address") @db.VarChar(80)
+  recipientAddress String   @map("recipient_address") @db.VarChar(80)
+  created          DateTime @default(now()) @db.DateTime(0)
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book             books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, bookId], map: "uniq_user_book_purchase")
+  @@index([bookId])
+  @@map("purchases")
 }
 
 model Notification {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { FollowModule } from './presentation/modules/follow';
 import { LikeModule } from './presentation/modules/like';
 import { NotificationModule } from './presentation/modules/notification';
 import { DiscoveryModule } from './presentation/modules/discovery';
+import { PurchaseModule } from './presentation/modules/purchase';
 
 @Module({
   imports: [
@@ -50,6 +51,7 @@ import { DiscoveryModule } from './presentation/modules/discovery';
     LikeModule,
     NotificationModule,
     DiscoveryModule,
+    PurchaseModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/application/usecases/purchases/create-purchase.spec.ts
+++ b/apps/api/src/application/usecases/purchases/create-purchase.spec.ts
@@ -1,0 +1,174 @@
+import { CreatePurchaseUseCase } from './create-purchase';
+import { IPurchaseRepository } from '../../../domain/repositories/purchase';
+import { IBookRepository } from '../../../domain/repositories/book';
+import { IPaymentVerifier } from '../../../domain/services/payment-verifier';
+import { Book } from '../../../domain/models/book';
+import { Purchase } from '../../../domain/models/purchase';
+
+describe('CreatePurchaseUseCase', () => {
+  let useCase: CreatePurchaseUseCase;
+  let purchaseRepository: jest.Mocked<IPurchaseRepository>;
+  let bookRepository: jest.Mocked<IBookRepository>;
+  let paymentVerifier: jest.Mocked<IPaymentVerifier>;
+
+  const purchasableBook = Book.fromDatabase(
+    '1',
+    'owner-1',
+    1,
+    'タイトル',
+    '著者',
+    'カテゴリ',
+    'image.jpg',
+    '★',
+    '秘密のメモ',
+    false,
+    true, // isPurchasable
+    null,
+    new Date(),
+    new Date(),
+  );
+
+  const baseParams = {
+    userId: 'buyer-1',
+    bookId: 1,
+    txDigest: 'digest-1',
+    senderAddress: '0xbeef',
+    network: 'testnet',
+  };
+
+  beforeEach(() => {
+    purchaseRepository = {
+      create: jest.fn(),
+      findByUserAndBook: jest.fn(),
+      findByTxDigest: jest.fn(),
+      findBookIdsByUser: jest.fn(),
+    };
+    bookRepository = {
+      findById: jest.fn(),
+    } as unknown as jest.Mocked<IBookRepository>;
+    paymentVerifier = {
+      verify: jest.fn(),
+    };
+    useCase = new CreatePurchaseUseCase(
+      purchaseRepository,
+      bookRepository,
+      paymentVerifier,
+    );
+  });
+
+  it('検証に成功すると購入を作成する', async () => {
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    purchaseRepository.findByUserAndBook.mockResolvedValue(null);
+    purchaseRepository.findByTxDigest.mockResolvedValue(null);
+    paymentVerifier.verify.mockResolvedValue({
+      valid: true,
+      amountReceived: 10000000n,
+      recipient: '0xcafe',
+      sender: '0xbeef',
+    });
+    const saved = Purchase.create({
+      userId: 'buyer-1',
+      bookId: 1,
+      txDigest: 'digest-1',
+      network: 'testnet',
+      amount: '10000000',
+      senderAddress: '0xbeef',
+      recipientAddress: '0xcafe',
+    });
+    purchaseRepository.create.mockResolvedValue(saved);
+
+    const result = await useCase.execute(baseParams);
+
+    expect(result).toBe(saved);
+    expect(purchaseRepository.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('書籍が存在しない場合エラーになる', async () => {
+    bookRepository.findById.mockResolvedValue(null);
+    await expect(useCase.execute(baseParams)).rejects.toThrow(
+      '書籍が見つかりません',
+    );
+  });
+
+  it('購入対象でない書籍の場合エラーになる', async () => {
+    const notPurchasable = Book.fromDatabase(
+      '1',
+      'owner-1',
+      1,
+      'タイトル',
+      '著者',
+      'カテゴリ',
+      'image.jpg',
+      '★',
+      'メモ',
+      false,
+      false,
+      null,
+      new Date(),
+      new Date(),
+    );
+    bookRepository.findById.mockResolvedValue(notPurchasable);
+    await expect(useCase.execute(baseParams)).rejects.toThrow(
+      'この書籍は購入対象ではありません',
+    );
+  });
+
+  it('自分の書籍は購入できない', async () => {
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    await expect(
+      useCase.execute({ ...baseParams, userId: 'owner-1' }),
+    ).rejects.toThrow('自分の書籍は購入できません');
+  });
+
+  it('購入済みの場合は既存の購入を返す（冪等）', async () => {
+    const existing = Purchase.create({
+      userId: 'buyer-1',
+      bookId: 1,
+      txDigest: 'old-digest',
+      network: 'testnet',
+      amount: '10000000',
+      senderAddress: '0xbeef',
+      recipientAddress: '0xcafe',
+    });
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    purchaseRepository.findByUserAndBook.mockResolvedValue(existing);
+
+    const result = await useCase.execute(baseParams);
+
+    expect(result).toBe(existing);
+    expect(paymentVerifier.verify).not.toHaveBeenCalled();
+    expect(purchaseRepository.create).not.toHaveBeenCalled();
+  });
+
+  it('トランザクションが既に使用済みの場合エラーになる', async () => {
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    purchaseRepository.findByUserAndBook.mockResolvedValue(null);
+    purchaseRepository.findByTxDigest.mockResolvedValue(
+      Purchase.create({
+        userId: 'other',
+        bookId: 1,
+        txDigest: 'digest-1',
+        network: 'testnet',
+        amount: '10000000',
+        senderAddress: '0xdead',
+        recipientAddress: '0xcafe',
+      }),
+    );
+    await expect(useCase.execute(baseParams)).rejects.toThrow(
+      'このトランザクションは既に使用されています',
+    );
+  });
+
+  it('検証に失敗した場合エラーになる', async () => {
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    purchaseRepository.findByUserAndBook.mockResolvedValue(null);
+    purchaseRepository.findByTxDigest.mockResolvedValue(null);
+    paymentVerifier.verify.mockResolvedValue({
+      valid: false,
+      reason: '送金額が不足しています',
+    });
+    await expect(useCase.execute(baseParams)).rejects.toThrow(
+      '決済の検証に失敗しました: 送金額が不足しています',
+    );
+  });
+});

--- a/apps/api/src/application/usecases/purchases/create-purchase.spec.ts
+++ b/apps/api/src/application/usecases/purchases/create-purchase.spec.ts
@@ -1,15 +1,27 @@
 import { CreatePurchaseUseCase } from './create-purchase';
 import { IPurchaseRepository } from '../../../domain/repositories/purchase';
 import { IBookRepository } from '../../../domain/repositories/book';
+import { IUserRepository } from '../../../domain/repositories/user';
 import { IPaymentVerifier } from '../../../domain/services/payment-verifier';
 import { Book } from '../../../domain/models/book';
 import { Purchase } from '../../../domain/models/purchase';
+import { User } from '../../../domain/models/user';
 
 describe('CreatePurchaseUseCase', () => {
   let useCase: CreatePurchaseUseCase;
   let purchaseRepository: jest.Mocked<IPurchaseRepository>;
   let bookRepository: jest.Mocked<IBookRepository>;
+  let userRepository: jest.Mocked<IUserRepository>;
   let paymentVerifier: jest.Mocked<IPaymentVerifier>;
+
+  const owner = User.fromDatabase(
+    'owner-1',
+    '出品者',
+    'owner@example.com',
+    null,
+    false,
+    '0xcafe',
+  );
 
   const purchasableBook = Book.fromDatabase(
     '1',
@@ -46,12 +58,18 @@ describe('CreatePurchaseUseCase', () => {
     bookRepository = {
       findById: jest.fn(),
     } as unknown as jest.Mocked<IBookRepository>;
+    userRepository = {
+      findById: jest.fn(),
+    } as unknown as jest.Mocked<IUserRepository>;
     paymentVerifier = {
       verify: jest.fn(),
     };
+    // 既定で所有者は受取アドレス登録済み
+    userRepository.findById.mockResolvedValue(owner);
     useCase = new CreatePurchaseUseCase(
       purchaseRepository,
       bookRepository,
+      userRepository,
       paymentVerifier,
     );
   });
@@ -118,6 +136,16 @@ describe('CreatePurchaseUseCase', () => {
     await expect(
       useCase.execute({ ...baseParams, userId: 'owner-1' }),
     ).rejects.toThrow('自分の書籍は購入できません');
+  });
+
+  it('出品者が受取アドレス未登録の場合エラーになる', async () => {
+    bookRepository.findById.mockResolvedValue(purchasableBook);
+    userRepository.findById.mockResolvedValue(
+      User.fromDatabase('owner-1', '出品者', null, null, false, null),
+    );
+    await expect(useCase.execute(baseParams)).rejects.toThrow(
+      '出品者が受取アドレスを設定していないため購入できません',
+    );
   });
 
   it('購入済みの場合は既存の購入を返す（冪等）', async () => {

--- a/apps/api/src/application/usecases/purchases/create-purchase.ts
+++ b/apps/api/src/application/usecases/purchases/create-purchase.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { Purchase } from '../../../domain/models/purchase';
+import { IPurchaseRepository } from '../../../domain/repositories/purchase';
+import { IBookRepository } from '../../../domain/repositories/book';
+import { IPaymentVerifier } from '../../../domain/services/payment-verifier';
+
+@Injectable()
+export class CreatePurchaseUseCase {
+  constructor(
+    private readonly purchaseRepository: IPurchaseRepository,
+    private readonly bookRepository: IBookRepository,
+    private readonly paymentVerifier: IPaymentVerifier,
+  ) {}
+
+  async execute(params: {
+    userId: string;
+    bookId: number;
+    txDigest: string;
+    senderAddress: string;
+    network: string;
+  }): Promise<Purchase> {
+    const book = await this.bookRepository.findById(String(params.bookId));
+    if (!book) {
+      throw new Error('書籍が見つかりません');
+    }
+    if (!book.isPurchasable) {
+      throw new Error('この書籍は購入対象ではありません');
+    }
+    if (book.userId === params.userId) {
+      throw new Error('自分の書籍は購入できません');
+    }
+
+    // すでに購入済みなら冪等にそのまま返す
+    const existing = await this.purchaseRepository.findByUserAndBook(
+      params.userId,
+      params.bookId,
+    );
+    if (existing) {
+      return existing;
+    }
+
+    // 同一トランザクションの二重利用を防ぐ
+    const duplicated = await this.purchaseRepository.findByTxDigest(
+      params.txDigest,
+    );
+    if (duplicated) {
+      throw new Error('このトランザクションは既に使用されています');
+    }
+
+    // ブロックチェーン上で実際に決済が成立しているか検証する
+    const result = await this.paymentVerifier.verify({
+      txDigest: params.txDigest,
+      senderAddress: params.senderAddress,
+      network: params.network,
+    });
+    if (!result.valid) {
+      throw new Error(`決済の検証に失敗しました: ${result.reason ?? '不明'}`);
+    }
+
+    const purchase = Purchase.create({
+      userId: params.userId,
+      bookId: params.bookId,
+      txDigest: params.txDigest,
+      network: params.network,
+      amount: (result.amountReceived ?? 0n).toString(),
+      senderAddress: result.sender ?? params.senderAddress,
+      recipientAddress: result.recipient ?? '',
+    });
+
+    return this.purchaseRepository.create(purchase);
+  }
+}

--- a/apps/api/src/application/usecases/purchases/create-purchase.ts
+++ b/apps/api/src/application/usecases/purchases/create-purchase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Purchase } from '../../../domain/models/purchase';
 import { IPurchaseRepository } from '../../../domain/repositories/purchase';
 import { IBookRepository } from '../../../domain/repositories/book';
+import { IUserRepository } from '../../../domain/repositories/user';
 import { IPaymentVerifier } from '../../../domain/services/payment-verifier';
 
 @Injectable()
@@ -9,6 +10,7 @@ export class CreatePurchaseUseCase {
   constructor(
     private readonly purchaseRepository: IPurchaseRepository,
     private readonly bookRepository: IBookRepository,
+    private readonly userRepository: IUserRepository,
     private readonly paymentVerifier: IPaymentVerifier,
   ) {}
 
@@ -28,6 +30,12 @@ export class CreatePurchaseUseCase {
     }
     if (book.userId === params.userId) {
       throw new Error('自分の書籍は購入できません');
+    }
+
+    // 送金先は本の所有者の受取アドレス。未登録なら購入不可
+    const owner = await this.userRepository.findById(book.userId);
+    if (!owner?.suiAddress) {
+      throw new Error('出品者が受取アドレスを設定していないため購入できません');
     }
 
     // すでに購入済みなら冪等にそのまま返す
@@ -52,6 +60,7 @@ export class CreatePurchaseUseCase {
       txDigest: params.txDigest,
       senderAddress: params.senderAddress,
       network: params.network,
+      expectedRecipient: owner.suiAddress,
     });
     if (!result.valid) {
       throw new Error(`決済の検証に失敗しました: ${result.reason ?? '不明'}`);

--- a/apps/api/src/application/usecases/purchases/get-book-payment-recipient.ts
+++ b/apps/api/src/application/usecases/purchases/get-book-payment-recipient.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { IBookRepository } from '../../../domain/repositories/book';
+import { IUserRepository } from '../../../domain/repositories/user';
+
+/**
+ * 指定した本の支払い先（所有者の Sui 受取アドレス）を返す。
+ * 購入対象でない・所有者が未登録の場合は null。
+ */
+@Injectable()
+export class GetBookPaymentRecipientUseCase {
+  constructor(
+    private readonly bookRepository: IBookRepository,
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute(bookId: number): Promise<string | null> {
+    const book = await this.bookRepository.findById(String(bookId));
+    if (!book || !book.isPurchasable) {
+      return null;
+    }
+    const owner = await this.userRepository.findById(book.userId);
+    return owner?.suiAddress ?? null;
+  }
+}

--- a/apps/api/src/application/usecases/purchases/get-my-purchased-book-ids.ts
+++ b/apps/api/src/application/usecases/purchases/get-my-purchased-book-ids.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { IPurchaseRepository } from '../../../domain/repositories/purchase';
+
+@Injectable()
+export class GetMyPurchasedBookIdsUseCase {
+  constructor(private readonly purchaseRepository: IPurchaseRepository) {}
+
+  async execute(userId: string): Promise<number[]> {
+    return this.purchaseRepository.findBookIdsByUser(userId);
+  }
+}

--- a/apps/api/src/application/usecases/purchases/get-purchased-book-memo.ts
+++ b/apps/api/src/application/usecases/purchases/get-purchased-book-memo.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { IPurchaseRepository } from '../../../domain/repositories/purchase';
+import { IBookRepository } from '../../../domain/repositories/book';
+
+/**
+ * 購入済みユーザー向けにメモ本文を返すユースケース。
+ * - 所有者: 常に全文を返す
+ * - 公開メモ: マスキング済みの内容を返す
+ * - 非公開メモ: 購入済みの場合のみ全文を返す（未購入は null）
+ */
+@Injectable()
+export class GetPurchasedBookMemoUseCase {
+  constructor(
+    private readonly purchaseRepository: IPurchaseRepository,
+    private readonly bookRepository: IBookRepository,
+  ) {}
+
+  async execute(userId: string, bookId: number): Promise<string | null> {
+    const book = await this.bookRepository.findById(String(bookId));
+    if (!book) {
+      return null;
+    }
+
+    const isOwner = book.userId === userId;
+    if (isOwner) {
+      return book.memo;
+    }
+
+    if (book.isPublicMemo) {
+      return book.getSanitizedMemo(false);
+    }
+
+    const purchase = await this.purchaseRepository.findByUserAndBook(
+      userId,
+      bookId,
+    );
+    if (!purchase) {
+      return null;
+    }
+
+    return book.memo;
+  }
+}

--- a/apps/api/src/application/usecases/users/get-my-sui-address.ts
+++ b/apps/api/src/application/usecases/users/get-my-sui-address.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { IUserRepository } from '../../../domain/repositories/user';
+
+@Injectable()
+export class GetMySuiAddressUseCase {
+  constructor(private readonly userRepository: IUserRepository) {}
+
+  async execute(userId: string): Promise<string | null> {
+    const user = await this.userRepository.findById(userId);
+    return user?.suiAddress ?? null;
+  }
+}

--- a/apps/api/src/application/usecases/users/update-sui-address.ts
+++ b/apps/api/src/application/usecases/users/update-sui-address.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '../../../domain/models/user';
+import { IUserRepository } from '../../../domain/repositories/user';
+
+@Injectable()
+export class UpdateSuiAddressUseCase {
+  constructor(private readonly userRepository: IUserRepository) {}
+
+  /**
+   * Sui の受取アドレスを更新する。
+   * 空文字を渡すと未設定（null）にリセットされる。
+   */
+  async execute(userId: string, suiAddress: string): Promise<User> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new Error('ユーザーが見つかりません');
+    }
+    // ドメインモデルでバリデーション（形式チェック・空文字のリセット）
+    user.updateSuiAddress(suiAddress);
+    return this.userRepository.updateSuiAddress(userId, user.suiAddress);
+  }
+}

--- a/apps/api/src/domain/models/purchase.spec.ts
+++ b/apps/api/src/domain/models/purchase.spec.ts
@@ -1,0 +1,100 @@
+import { Purchase } from './purchase';
+
+describe('Purchase', () => {
+  const validParams = {
+    userId: 'user-1',
+    bookId: 1,
+    txDigest: 'A1b2C3d4E5f6G7h8',
+    network: 'testnet',
+    amount: '10000000',
+    senderAddress: '0xabc123',
+    recipientAddress: '0xdef456',
+  };
+
+  describe('create', () => {
+    it('有効なパラメータで購入を作成できる', () => {
+      const purchase = Purchase.create(validParams);
+
+      expect(purchase.id).toBeNull();
+      expect(purchase.userId).toBe('user-1');
+      expect(purchase.bookId).toBe(1);
+      expect(purchase.txDigest).toBe('A1b2C3d4E5f6G7h8');
+      expect(purchase.network).toBe('testnet');
+      expect(purchase.amount).toBe('10000000');
+      expect(purchase.senderAddress).toBe('0xabc123');
+      expect(purchase.recipientAddress).toBe('0xdef456');
+      expect(purchase.created).toBeInstanceOf(Date);
+    });
+
+    it('txDigestの前後空白がトリムされる', () => {
+      const purchase = Purchase.create({
+        ...validParams,
+        txDigest: '  digest  ',
+      });
+      expect(purchase.txDigest).toBe('digest');
+    });
+
+    it('bookIdが0以下の場合エラーになる', () => {
+      expect(() => Purchase.create({ ...validParams, bookId: 0 })).toThrow(
+        '書籍IDが不正です',
+      );
+    });
+
+    it('txDigestが空の場合エラーになる', () => {
+      expect(() => Purchase.create({ ...validParams, txDigest: '' })).toThrow(
+        'トランザクションダイジェストは必須です',
+      );
+    });
+
+    it('サポート外ネットワークの場合エラーになる', () => {
+      expect(() =>
+        Purchase.create({ ...validParams, network: 'ethereum' }),
+      ).toThrow('サポートされていないネットワークです: ethereum');
+    });
+
+    it('金額が0以下の場合エラーになる', () => {
+      expect(() => Purchase.create({ ...validParams, amount: '0' })).toThrow(
+        '決済金額が不正です',
+      );
+    });
+
+    it('金額が数値でない場合エラーになる', () => {
+      expect(() => Purchase.create({ ...validParams, amount: 'abc' })).toThrow(
+        '決済金額が不正です',
+      );
+    });
+
+    it('送金元アドレスが不正な場合エラーになる', () => {
+      expect(() =>
+        Purchase.create({ ...validParams, senderAddress: 'invalid' }),
+      ).toThrow('送金元アドレスが不正です');
+    });
+
+    it('送金先アドレスが不正な場合エラーになる', () => {
+      expect(() =>
+        Purchase.create({ ...validParams, recipientAddress: 'invalid' }),
+      ).toThrow('送金先アドレスが不正です');
+    });
+  });
+
+  describe('fromDatabase', () => {
+    it('DBからの復元ができる', () => {
+      const created = new Date('2025-01-01');
+      const purchase = Purchase.fromDatabase(
+        '1',
+        'user-1',
+        2,
+        'digest',
+        'testnet',
+        '10000000',
+        '0xabc',
+        '0xdef',
+        created,
+      );
+
+      expect(purchase.id).toBe('1');
+      expect(purchase.bookId).toBe(2);
+      expect(purchase.created).toBe(created);
+    });
+  });
+});

--- a/apps/api/src/domain/models/purchase.ts
+++ b/apps/api/src/domain/models/purchase.ts
@@ -1,0 +1,121 @@
+export class Purchase {
+  private constructor(
+    private readonly _id: string | null,
+    private readonly _userId: string,
+    private readonly _bookId: number,
+    private readonly _txDigest: string,
+    private readonly _network: string,
+    private readonly _amount: string,
+    private readonly _senderAddress: string,
+    private readonly _recipientAddress: string,
+    private readonly _created: Date,
+  ) {}
+
+  get id(): string | null {
+    return this._id;
+  }
+  get userId(): string {
+    return this._userId;
+  }
+  get bookId(): number {
+    return this._bookId;
+  }
+  get txDigest(): string {
+    return this._txDigest;
+  }
+  get network(): string {
+    return this._network;
+  }
+  get amount(): string {
+    return this._amount;
+  }
+  get senderAddress(): string {
+    return this._senderAddress;
+  }
+  get recipientAddress(): string {
+    return this._recipientAddress;
+  }
+  get created(): Date {
+    return this._created;
+  }
+
+  private static readonly ALLOWED_NETWORKS = [
+    'mainnet',
+    'testnet',
+    'devnet',
+    'localnet',
+  ];
+
+  private static isSuiAddress(value: string): boolean {
+    return /^0x[0-9a-fA-F]+$/.test(value);
+  }
+
+  static create(params: {
+    userId: string;
+    bookId: number;
+    txDigest: string;
+    network: string;
+    amount: string;
+    senderAddress: string;
+    recipientAddress: string;
+  }): Purchase {
+    if (!params.userId) {
+      throw new Error('ユーザーIDは必須です');
+    }
+    if (!params.bookId || params.bookId <= 0) {
+      throw new Error('書籍IDが不正です');
+    }
+    if (!params.txDigest || params.txDigest.trim().length === 0) {
+      throw new Error('トランザクションダイジェストは必須です');
+    }
+    if (!Purchase.ALLOWED_NETWORKS.includes(params.network)) {
+      throw new Error(
+        `サポートされていないネットワークです: ${params.network}`,
+      );
+    }
+    if (!/^\d+$/.test(params.amount) || BigInt(params.amount) <= 0n) {
+      throw new Error('決済金額が不正です');
+    }
+    if (!Purchase.isSuiAddress(params.senderAddress)) {
+      throw new Error('送金元アドレスが不正です');
+    }
+    if (!Purchase.isSuiAddress(params.recipientAddress)) {
+      throw new Error('送金先アドレスが不正です');
+    }
+    return new Purchase(
+      null,
+      params.userId,
+      params.bookId,
+      params.txDigest.trim(),
+      params.network,
+      params.amount,
+      params.senderAddress,
+      params.recipientAddress,
+      new Date(),
+    );
+  }
+
+  static fromDatabase(
+    id: string,
+    userId: string,
+    bookId: number,
+    txDigest: string,
+    network: string,
+    amount: string,
+    senderAddress: string,
+    recipientAddress: string,
+    created: Date,
+  ): Purchase {
+    return new Purchase(
+      id,
+      userId,
+      bookId,
+      txDigest,
+      network,
+      amount,
+      senderAddress,
+      recipientAddress,
+      created,
+    );
+  }
+}

--- a/apps/api/src/domain/models/user.ts
+++ b/apps/api/src/domain/models/user.ts
@@ -5,6 +5,7 @@ export class User {
     private readonly _email: string | null,
     private readonly _image: string | null,
     private readonly _admin: boolean,
+    private _suiAddress: string | null,
   ) {}
 
   get id(): string {
@@ -22,6 +23,9 @@ export class User {
   get admin(): boolean {
     return this._admin;
   }
+  get suiAddress(): string | null {
+    return this._suiAddress;
+  }
 
   updateName(newName: string): void {
     if (!newName || newName.trim().length === 0) {
@@ -30,13 +34,30 @@ export class User {
     this._name = newName.trim();
   }
 
+  /**
+   * Sui の受取アドレスを更新する。
+   * 空文字は未設定（null）として扱い、それ以外は 0x + 16進の形式を要求する。
+   */
+  updateSuiAddress(newAddress: string | null): void {
+    const trimmed = (newAddress ?? '').trim();
+    if (trimmed === '') {
+      this._suiAddress = null;
+      return;
+    }
+    if (!/^0x[0-9a-fA-F]{1,64}$/.test(trimmed)) {
+      throw new Error('Suiアドレスの形式が正しくありません');
+    }
+    this._suiAddress = trimmed;
+  }
+
   static fromDatabase(
     id: string,
     name: string | null,
     email: string | null,
     image: string | null,
     admin: boolean,
+    suiAddress: string | null = null,
   ): User {
-    return new User(id, name, email, image, admin);
+    return new User(id, name, email, image, admin, suiAddress);
   }
 }

--- a/apps/api/src/domain/repositories/purchase.ts
+++ b/apps/api/src/domain/repositories/purchase.ts
@@ -1,0 +1,11 @@
+import { Purchase } from '../models/purchase';
+
+export abstract class IPurchaseRepository {
+  abstract create(purchase: Purchase): Promise<Purchase>;
+  abstract findByUserAndBook(
+    userId: string,
+    bookId: number,
+  ): Promise<Purchase | null>;
+  abstract findByTxDigest(txDigest: string): Promise<Purchase | null>;
+  abstract findBookIdsByUser(userId: string): Promise<number[]>;
+}

--- a/apps/api/src/domain/repositories/user.ts
+++ b/apps/api/src/domain/repositories/user.ts
@@ -4,5 +4,6 @@ export abstract class IUserRepository {
   abstract findById(id: string): Promise<User | null>;
   abstract findByName(name: string): Promise<User | null>;
   abstract updateName(id: string, name: string): Promise<User>;
+  abstract updateSuiAddress(id: string, address: string | null): Promise<User>;
   abstract delete(id: string): Promise<void>;
 }

--- a/apps/api/src/domain/services/payment-verifier.ts
+++ b/apps/api/src/domain/services/payment-verifier.ts
@@ -1,0 +1,26 @@
+export interface PaymentVerificationParams {
+  txDigest: string;
+  senderAddress: string;
+  network: string;
+}
+
+export interface PaymentVerificationResult {
+  valid: boolean;
+  reason?: string;
+  /** 実際に送金先が受け取った金額（MIST） */
+  amountReceived?: bigint;
+  /** 検証に使用した送金先アドレス */
+  recipient?: string;
+  /** トランザクションの送金元アドレス */
+  sender?: string;
+}
+
+/**
+ * ブロックチェーン上の決済トランザクションを検証するドメインサービス。
+ * 実装はインフラ層（Sui RPC など）に委ねる。
+ */
+export abstract class IPaymentVerifier {
+  abstract verify(
+    params: PaymentVerificationParams,
+  ): Promise<PaymentVerificationResult>;
+}

--- a/apps/api/src/domain/services/payment-verifier.ts
+++ b/apps/api/src/domain/services/payment-verifier.ts
@@ -2,6 +2,8 @@ export interface PaymentVerificationParams {
   txDigest: string;
   senderAddress: string;
   network: string;
+  /** 期待する送金先（本の所有者の受取アドレス） */
+  expectedRecipient: string;
 }
 
 export interface PaymentVerificationResult {

--- a/apps/api/src/infrastructure/repositories/purchase.ts
+++ b/apps/api/src/infrastructure/repositories/purchase.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../database/prisma.service';
+import { Purchase } from '../../domain/models/purchase';
+import { IPurchaseRepository } from '../../domain/repositories/purchase';
+
+@Injectable()
+export class PurchaseRepository implements IPurchaseRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(purchase: Purchase): Promise<Purchase> {
+    const row = await this.prisma.purchase.create({
+      data: {
+        userId: purchase.userId,
+        bookId: purchase.bookId,
+        txDigest: purchase.txDigest,
+        network: purchase.network,
+        amount: purchase.amount,
+        senderAddress: purchase.senderAddress,
+        recipientAddress: purchase.recipientAddress,
+      },
+    });
+    return this.toEntity(row);
+  }
+
+  async findByUserAndBook(
+    userId: string,
+    bookId: number,
+  ): Promise<Purchase | null> {
+    const row = await this.prisma.purchase.findUnique({
+      where: { userId_bookId: { userId, bookId } },
+    });
+    return row ? this.toEntity(row) : null;
+  }
+
+  async findByTxDigest(txDigest: string): Promise<Purchase | null> {
+    const row = await this.prisma.purchase.findUnique({
+      where: { txDigest },
+    });
+    return row ? this.toEntity(row) : null;
+  }
+
+  async findBookIdsByUser(userId: string): Promise<number[]> {
+    const rows = await this.prisma.purchase.findMany({
+      where: { userId },
+      select: { bookId: true },
+    });
+    return rows.map((r) => r.bookId);
+  }
+
+  private toEntity(row: {
+    id: number;
+    userId: string;
+    bookId: number;
+    txDigest: string;
+    network: string;
+    amount: string;
+    senderAddress: string;
+    recipientAddress: string;
+    created: Date;
+  }): Purchase {
+    return Purchase.fromDatabase(
+      row.id.toString(),
+      row.userId,
+      row.bookId,
+      row.txDigest,
+      row.network,
+      row.amount,
+      row.senderAddress,
+      row.recipientAddress,
+      row.created ?? new Date(),
+    );
+  }
+}

--- a/apps/api/src/infrastructure/repositories/user.ts
+++ b/apps/api/src/infrastructure/repositories/user.ts
@@ -12,7 +12,14 @@ export class UserRepository implements IUserRepository {
       where: { id },
     });
     if (!row) return null;
-    return User.fromDatabase(row.id, row.name, row.email, row.image, row.admin);
+    return User.fromDatabase(
+      row.id,
+      row.name,
+      row.email,
+      row.image,
+      row.admin,
+      row.suiAddress,
+    );
   }
 
   async findByName(name: string): Promise<User | null> {
@@ -20,7 +27,14 @@ export class UserRepository implements IUserRepository {
       where: { name },
     });
     if (!row) return null;
-    return User.fromDatabase(row.id, row.name, row.email, row.image, row.admin);
+    return User.fromDatabase(
+      row.id,
+      row.name,
+      row.email,
+      row.image,
+      row.admin,
+      row.suiAddress,
+    );
   }
 
   async updateName(id: string, name: string): Promise<User> {
@@ -28,7 +42,29 @@ export class UserRepository implements IUserRepository {
       where: { id },
       data: { name },
     });
-    return User.fromDatabase(row.id, row.name, row.email, row.image, row.admin);
+    return User.fromDatabase(
+      row.id,
+      row.name,
+      row.email,
+      row.image,
+      row.admin,
+      row.suiAddress,
+    );
+  }
+
+  async updateSuiAddress(id: string, address: string | null): Promise<User> {
+    const row = await this.prisma.user.update({
+      where: { id },
+      data: { suiAddress: address },
+    });
+    return User.fromDatabase(
+      row.id,
+      row.name,
+      row.email,
+      row.image,
+      row.admin,
+      row.suiAddress,
+    );
   }
 
   async delete(id: string): Promise<void> {

--- a/apps/api/src/infrastructure/sui/sui-payment-verifier.ts
+++ b/apps/api/src/infrastructure/sui/sui-payment-verifier.ts
@@ -1,0 +1,132 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
+import {
+  IPaymentVerifier,
+  PaymentVerificationParams,
+  PaymentVerificationResult,
+} from '../../domain/services/payment-verifier';
+
+const SUI_COIN_TYPE = '0x2::sui::SUI';
+const DEFAULT_AMOUNT_MIST = '10000000'; // 0.01 SUI
+
+type SuiNetwork = 'mainnet' | 'testnet' | 'devnet' | 'localnet';
+
+/**
+ * Sui ブロックチェーン上の SUI 送金トランザクションを検証する。
+ *
+ * 環境変数:
+ * - SUI_NETWORK            検証対象ネットワーク（既定: testnet）
+ * - SUI_RECIPIENT_ADDRESS  送金先（受取）アドレス
+ * - SUI_PAYMENT_AMOUNT_MIST 必要な金額（MIST, 既定: 10000000 = 0.01 SUI）
+ * - SUI_FULLNODE_URL       任意。フルノードのURLを上書きする
+ * - SUI_PAYMENT_VERIFY     'false' でオンチェーン検証をスキップ（プレビュー/サンドボックス用）
+ */
+@Injectable()
+export class SuiPaymentVerifier implements IPaymentVerifier {
+  private readonly logger = new Logger(SuiPaymentVerifier.name);
+
+  async verify(
+    params: PaymentVerificationParams,
+  ): Promise<PaymentVerificationResult> {
+    const expectedNetwork = process.env.SUI_NETWORK || 'testnet';
+    const expectedRecipient = process.env.SUI_RECIPIENT_ADDRESS;
+    const expectedAmount = BigInt(
+      process.env.SUI_PAYMENT_AMOUNT_MIST || DEFAULT_AMOUNT_MIST,
+    );
+
+    if (!expectedRecipient) {
+      return { valid: false, reason: '送金先アドレスが未設定です' };
+    }
+    if (params.network !== expectedNetwork) {
+      return {
+        valid: false,
+        reason: `ネットワークが一致しません (expected: ${expectedNetwork})`,
+      };
+    }
+
+    // オンチェーン検証を無効化している場合（外部ネットワーク非対応環境など）
+    if (process.env.SUI_PAYMENT_VERIFY === 'false') {
+      this.logger.warn(
+        'SUI_PAYMENT_VERIFY=false のためオンチェーン検証をスキップしました',
+      );
+      return {
+        valid: true,
+        amountReceived: expectedAmount,
+        recipient: expectedRecipient,
+        sender: params.senderAddress,
+      };
+    }
+
+    try {
+      const url =
+        process.env.SUI_FULLNODE_URL ||
+        getFullnodeUrl(expectedNetwork as SuiNetwork);
+      const client = new SuiClient({ url });
+
+      const tx = await client.getTransactionBlock({
+        digest: params.txDigest,
+        options: {
+          showEffects: true,
+          showBalanceChanges: true,
+          showInput: true,
+        },
+      });
+
+      const status = tx.effects?.status?.status;
+      if (status !== 'success') {
+        return {
+          valid: false,
+          reason: `トランザクションが成功していません (status: ${status})`,
+        };
+      }
+
+      const sender = tx.transaction?.data?.sender;
+      if (
+        sender &&
+        normalizeSuiAddress(sender) !==
+          normalizeSuiAddress(params.senderAddress)
+      ) {
+        return { valid: false, reason: '送金元アドレスが一致しません' };
+      }
+
+      // 送金先が受け取った SUI の合計を集計する
+      let received = 0n;
+      for (const change of tx.balanceChanges ?? []) {
+        const owner = change.owner;
+        const ownerAddress =
+          owner && typeof owner === 'object' && 'AddressOwner' in owner
+            ? (owner as { AddressOwner: string }).AddressOwner
+            : null;
+        if (
+          ownerAddress &&
+          normalizeSuiAddress(ownerAddress) ===
+            normalizeSuiAddress(expectedRecipient) &&
+          change.coinType === SUI_COIN_TYPE
+        ) {
+          received += BigInt(change.amount);
+        }
+      }
+
+      if (received < expectedAmount) {
+        return {
+          valid: false,
+          reason: `送金額が不足しています (${received} < ${expectedAmount} MIST)`,
+        };
+      }
+
+      return {
+        valid: true,
+        amountReceived: received,
+        recipient: expectedRecipient,
+        sender: sender ?? params.senderAddress,
+      };
+    } catch (e) {
+      this.logger.error('Sui トランザクション検証中にエラー', e);
+      return {
+        valid: false,
+        reason: 'トランザクションの取得に失敗しました',
+      };
+    }
+  }
+}

--- a/apps/api/src/infrastructure/sui/sui-payment-verifier.ts
+++ b/apps/api/src/infrastructure/sui/sui-payment-verifier.ts
@@ -15,9 +15,11 @@ type SuiNetwork = 'mainnet' | 'testnet' | 'devnet' | 'localnet';
 /**
  * Sui ブロックチェーン上の SUI 送金トランザクションを検証する。
  *
+ * 送金先（受取）アドレスは本の所有者ごとに異なるため、呼び出し側から
+ * params.expectedRecipient で受け取る。
+ *
  * 環境変数:
  * - SUI_NETWORK            検証対象ネットワーク（既定: testnet）
- * - SUI_RECIPIENT_ADDRESS  送金先（受取）アドレス
  * - SUI_PAYMENT_AMOUNT_MIST 必要な金額（MIST, 既定: 10000000 = 0.01 SUI）
  * - SUI_FULLNODE_URL       任意。フルノードのURLを上書きする
  * - SUI_PAYMENT_VERIFY     'false' でオンチェーン検証をスキップ（プレビュー/サンドボックス用）
@@ -30,7 +32,7 @@ export class SuiPaymentVerifier implements IPaymentVerifier {
     params: PaymentVerificationParams,
   ): Promise<PaymentVerificationResult> {
     const expectedNetwork = process.env.SUI_NETWORK || 'testnet';
-    const expectedRecipient = process.env.SUI_RECIPIENT_ADDRESS;
+    const expectedRecipient = params.expectedRecipient;
     const expectedAmount = BigInt(
       process.env.SUI_PAYMENT_AMOUNT_MIST || DEFAULT_AMOUNT_MIST,
     );

--- a/apps/api/src/presentation/dto/purchase.ts
+++ b/apps/api/src/presentation/dto/purchase.ts
@@ -32,6 +32,12 @@ export class GetPurchasedBookMemoInput {
   bookId: number;
 }
 
+@InputType()
+export class GetBookPaymentRecipientInput {
+  @Field(() => Int)
+  bookId: number;
+}
+
 @ObjectType()
 export class PurchaseResponse {
   @Field(() => ID)

--- a/apps/api/src/presentation/dto/purchase.ts
+++ b/apps/api/src/presentation/dto/purchase.ts
@@ -1,0 +1,60 @@
+import {
+  Field,
+  ObjectType,
+  InputType,
+  ID,
+  Int,
+  GraphQLISODateTime,
+} from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+@InputType()
+export class CreatePurchaseInput {
+  @Field(() => Int)
+  bookId: number;
+
+  @Field()
+  @IsNotEmpty({ message: 'トランザクションダイジェストは必須です' })
+  txDigest: string;
+
+  @Field()
+  @IsNotEmpty({ message: '送金元アドレスは必須です' })
+  senderAddress: string;
+
+  @Field()
+  @IsNotEmpty({ message: 'ネットワークは必須です' })
+  network: string;
+}
+
+@InputType()
+export class GetPurchasedBookMemoInput {
+  @Field(() => Int)
+  bookId: number;
+}
+
+@ObjectType()
+export class PurchaseResponse {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => Int)
+  bookId: number;
+
+  @Field()
+  txDigest: string;
+
+  @Field()
+  network: string;
+
+  @Field()
+  amount: string;
+
+  @Field()
+  senderAddress: string;
+
+  @Field()
+  recipientAddress: string;
+
+  @Field(() => GraphQLISODateTime)
+  created: Date;
+}

--- a/apps/api/src/presentation/dto/user.ts
+++ b/apps/api/src/presentation/dto/user.ts
@@ -1,9 +1,18 @@
 import { Field, ObjectType, InputType } from '@nestjs/graphql';
+import { MaxLength } from 'class-validator';
 
 @InputType()
 export class UpdateUserNameInput {
   @Field()
   name: string;
+}
+
+@InputType()
+export class UpdateSuiAddressInput {
+  // 空文字は受取アドレスのリセットとして許可するため必須にはしない
+  @Field()
+  @MaxLength(70)
+  suiAddress: string;
 }
 
 @InputType()
@@ -22,4 +31,7 @@ export class CheckNameAvailableInput {
 export class UserResponse {
   @Field()
   name: string;
+
+  @Field({ nullable: true })
+  suiAddress?: string;
 }

--- a/apps/api/src/presentation/modules/purchase.ts
+++ b/apps/api/src/presentation/modules/purchase.ts
@@ -4,11 +4,14 @@ import { AuthModule } from '../../infrastructure/auth/auth.module';
 import { CreatePurchaseUseCase } from '../../application/usecases/purchases/create-purchase';
 import { GetMyPurchasedBookIdsUseCase } from '../../application/usecases/purchases/get-my-purchased-book-ids';
 import { GetPurchasedBookMemoUseCase } from '../../application/usecases/purchases/get-purchased-book-memo';
+import { GetBookPaymentRecipientUseCase } from '../../application/usecases/purchases/get-book-payment-recipient';
 import { PurchaseRepository } from '../../infrastructure/repositories/purchase';
 import { BookRepository } from '../../infrastructure/repositories/book';
+import { UserRepository } from '../../infrastructure/repositories/user';
 import { SuiPaymentVerifier } from '../../infrastructure/sui/sui-payment-verifier';
 import { IPurchaseRepository } from '../../domain/repositories/purchase';
 import { IBookRepository } from '../../domain/repositories/book';
+import { IUserRepository } from '../../domain/repositories/user';
 import { IPaymentVerifier } from '../../domain/services/payment-verifier';
 
 @Module({
@@ -18,6 +21,7 @@ import { IPaymentVerifier } from '../../domain/services/payment-verifier';
     CreatePurchaseUseCase,
     GetMyPurchasedBookIdsUseCase,
     GetPurchasedBookMemoUseCase,
+    GetBookPaymentRecipientUseCase,
     {
       provide: IPurchaseRepository,
       useClass: PurchaseRepository,
@@ -25,6 +29,10 @@ import { IPaymentVerifier } from '../../domain/services/payment-verifier';
     {
       provide: IBookRepository,
       useClass: BookRepository,
+    },
+    {
+      provide: IUserRepository,
+      useClass: UserRepository,
     },
     {
       provide: IPaymentVerifier,

--- a/apps/api/src/presentation/modules/purchase.ts
+++ b/apps/api/src/presentation/modules/purchase.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { PurchaseResolver } from '../resolvers/purchase';
+import { AuthModule } from '../../infrastructure/auth/auth.module';
+import { CreatePurchaseUseCase } from '../../application/usecases/purchases/create-purchase';
+import { GetMyPurchasedBookIdsUseCase } from '../../application/usecases/purchases/get-my-purchased-book-ids';
+import { GetPurchasedBookMemoUseCase } from '../../application/usecases/purchases/get-purchased-book-memo';
+import { PurchaseRepository } from '../../infrastructure/repositories/purchase';
+import { BookRepository } from '../../infrastructure/repositories/book';
+import { SuiPaymentVerifier } from '../../infrastructure/sui/sui-payment-verifier';
+import { IPurchaseRepository } from '../../domain/repositories/purchase';
+import { IBookRepository } from '../../domain/repositories/book';
+import { IPaymentVerifier } from '../../domain/services/payment-verifier';
+
+@Module({
+  imports: [AuthModule],
+  providers: [
+    PurchaseResolver,
+    CreatePurchaseUseCase,
+    GetMyPurchasedBookIdsUseCase,
+    GetPurchasedBookMemoUseCase,
+    {
+      provide: IPurchaseRepository,
+      useClass: PurchaseRepository,
+    },
+    {
+      provide: IBookRepository,
+      useClass: BookRepository,
+    },
+    {
+      provide: IPaymentVerifier,
+      useClass: SuiPaymentVerifier,
+    },
+  ],
+})
+export class PurchaseModule {}

--- a/apps/api/src/presentation/modules/user.ts
+++ b/apps/api/src/presentation/modules/user.ts
@@ -3,6 +3,8 @@ import { UserResolver } from '../resolvers/user';
 import { GetUserImageUseCase } from '../../application/usecases/users/get-user-image';
 import { CheckNameAvailableUseCase } from '../../application/usecases/users/check-name-available';
 import { UpdateUserNameUseCase } from '../../application/usecases/users/update-user-name';
+import { UpdateSuiAddressUseCase } from '../../application/usecases/users/update-sui-address';
+import { GetMySuiAddressUseCase } from '../../application/usecases/users/get-my-sui-address';
 import { DeleteUserUseCase } from '../../application/usecases/users/delete-user';
 import { UserRepository } from '../../infrastructure/repositories/user';
 import { AuthModule } from '../../infrastructure/auth/auth.module';
@@ -15,6 +17,8 @@ import { IUserRepository } from '../../domain/repositories/user';
     GetUserImageUseCase,
     CheckNameAvailableUseCase,
     UpdateUserNameUseCase,
+    UpdateSuiAddressUseCase,
+    GetMySuiAddressUseCase,
     DeleteUserUseCase,
     {
       provide: IUserRepository,

--- a/apps/api/src/presentation/resolvers/purchase.ts
+++ b/apps/api/src/presentation/resolvers/purchase.ts
@@ -1,0 +1,66 @@
+import { UseGuards } from '@nestjs/common';
+import { Query, Mutation, Resolver, Args, Int } from '@nestjs/graphql';
+import { GqlAuthGuard } from '../../infrastructure/auth/gql-auth.guard';
+import { CurrentUser } from '../../infrastructure/auth/current-user.decorator';
+import { CreatePurchaseUseCase } from '../../application/usecases/purchases/create-purchase';
+import { GetMyPurchasedBookIdsUseCase } from '../../application/usecases/purchases/get-my-purchased-book-ids';
+import { GetPurchasedBookMemoUseCase } from '../../application/usecases/purchases/get-purchased-book-memo';
+import { Purchase } from '../../domain/models/purchase';
+import {
+  CreatePurchaseInput,
+  GetPurchasedBookMemoInput,
+  PurchaseResponse,
+} from '../dto/purchase';
+
+@Resolver()
+@UseGuards(GqlAuthGuard)
+export class PurchaseResolver {
+  constructor(
+    private readonly createPurchaseUseCase: CreatePurchaseUseCase,
+    private readonly getMyPurchasedBookIdsUseCase: GetMyPurchasedBookIdsUseCase,
+    private readonly getPurchasedBookMemoUseCase: GetPurchasedBookMemoUseCase,
+  ) {}
+
+  @Mutation(() => PurchaseResponse)
+  async createPurchase(
+    @CurrentUser() user: { id: string },
+    @Args('input') input: CreatePurchaseInput,
+  ): Promise<PurchaseResponse> {
+    const purchase = await this.createPurchaseUseCase.execute({
+      userId: user.id,
+      bookId: input.bookId,
+      txDigest: input.txDigest,
+      senderAddress: input.senderAddress,
+      network: input.network,
+    });
+    return this.toResponse(purchase);
+  }
+
+  @Query(() => [Int])
+  async myPurchasedBookIds(
+    @CurrentUser() user: { id: string },
+  ): Promise<number[]> {
+    return this.getMyPurchasedBookIdsUseCase.execute(user.id);
+  }
+
+  @Query(() => String, { nullable: true })
+  async purchasedBookMemo(
+    @CurrentUser() user: { id: string },
+    @Args('input') input: GetPurchasedBookMemoInput,
+  ): Promise<string | null> {
+    return this.getPurchasedBookMemoUseCase.execute(user.id, input.bookId);
+  }
+
+  private toResponse(purchase: Purchase): PurchaseResponse {
+    return {
+      id: purchase.id ?? '',
+      bookId: purchase.bookId,
+      txDigest: purchase.txDigest,
+      network: purchase.network,
+      amount: purchase.amount,
+      senderAddress: purchase.senderAddress,
+      recipientAddress: purchase.recipientAddress,
+      created: purchase.created,
+    };
+  }
+}

--- a/apps/api/src/presentation/resolvers/purchase.ts
+++ b/apps/api/src/presentation/resolvers/purchase.ts
@@ -5,10 +5,12 @@ import { CurrentUser } from '../../infrastructure/auth/current-user.decorator';
 import { CreatePurchaseUseCase } from '../../application/usecases/purchases/create-purchase';
 import { GetMyPurchasedBookIdsUseCase } from '../../application/usecases/purchases/get-my-purchased-book-ids';
 import { GetPurchasedBookMemoUseCase } from '../../application/usecases/purchases/get-purchased-book-memo';
+import { GetBookPaymentRecipientUseCase } from '../../application/usecases/purchases/get-book-payment-recipient';
 import { Purchase } from '../../domain/models/purchase';
 import {
   CreatePurchaseInput,
   GetPurchasedBookMemoInput,
+  GetBookPaymentRecipientInput,
   PurchaseResponse,
 } from '../dto/purchase';
 
@@ -19,6 +21,7 @@ export class PurchaseResolver {
     private readonly createPurchaseUseCase: CreatePurchaseUseCase,
     private readonly getMyPurchasedBookIdsUseCase: GetMyPurchasedBookIdsUseCase,
     private readonly getPurchasedBookMemoUseCase: GetPurchasedBookMemoUseCase,
+    private readonly getBookPaymentRecipientUseCase: GetBookPaymentRecipientUseCase,
   ) {}
 
   @Mutation(() => PurchaseResponse)
@@ -49,6 +52,14 @@ export class PurchaseResolver {
     @Args('input') input: GetPurchasedBookMemoInput,
   ): Promise<string | null> {
     return this.getPurchasedBookMemoUseCase.execute(user.id, input.bookId);
+  }
+
+  // 本の支払い先（所有者の Sui 受取アドレス）。未登録なら null
+  @Query(() => String, { nullable: true })
+  async bookPaymentRecipient(
+    @Args('input') input: GetBookPaymentRecipientInput,
+  ): Promise<string | null> {
+    return this.getBookPaymentRecipientUseCase.execute(input.bookId);
   }
 
   private toResponse(purchase: Purchase): PurchaseResponse {

--- a/apps/api/src/presentation/resolvers/user.ts
+++ b/apps/api/src/presentation/resolvers/user.ts
@@ -3,12 +3,15 @@ import { Query, Mutation, Resolver, Args } from '@nestjs/graphql';
 import { GetUserImageUseCase } from '../../application/usecases/users/get-user-image';
 import { CheckNameAvailableUseCase } from '../../application/usecases/users/check-name-available';
 import { UpdateUserNameUseCase } from '../../application/usecases/users/update-user-name';
+import { UpdateSuiAddressUseCase } from '../../application/usecases/users/update-sui-address';
+import { GetMySuiAddressUseCase } from '../../application/usecases/users/get-my-sui-address';
 import { DeleteUserUseCase } from '../../application/usecases/users/delete-user';
 import { CurrentUser } from '../../infrastructure/auth/current-user.decorator';
 import { GqlAuthGuard } from '../../infrastructure/auth/gql-auth.guard';
 import {
   UserResponse,
   UpdateUserNameInput,
+  UpdateSuiAddressInput,
   GetUserImageInput,
   CheckNameAvailableInput,
 } from '../dto/user';
@@ -19,6 +22,8 @@ export class UserResolver {
     private readonly getUserImageUseCase: GetUserImageUseCase,
     private readonly checkNameAvailableUseCase: CheckNameAvailableUseCase,
     private readonly updateUserNameUseCase: UpdateUserNameUseCase,
+    private readonly updateSuiAddressUseCase: UpdateSuiAddressUseCase,
+    private readonly getMySuiAddressUseCase: GetMySuiAddressUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
   ) {}
 
@@ -46,6 +51,30 @@ export class UserResolver {
       input.name,
     );
     return { name: updated.name ?? '' };
+  }
+
+  @Query(() => String, { nullable: true })
+  @UseGuards(GqlAuthGuard)
+  async mySuiAddress(
+    @CurrentUser() user: { id: string },
+  ): Promise<string | null> {
+    return this.getMySuiAddressUseCase.execute(user.id);
+  }
+
+  @Mutation(() => UserResponse)
+  @UseGuards(GqlAuthGuard)
+  async updateSuiAddress(
+    @CurrentUser() user: { id: string },
+    @Args('input') input: UpdateSuiAddressInput,
+  ): Promise<UserResponse> {
+    const updated = await this.updateSuiAddressUseCase.execute(
+      user.id,
+      input.suiAddress,
+    );
+    return {
+      name: updated.name ?? '',
+      suiAddress: updated.suiAddress ?? undefined,
+    };
   }
 
   @Mutation(() => Boolean)

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -113,6 +113,7 @@ type YearlyTopBookResponse {
 
 type UserResponse {
   name: String!
+  suiAddress: String
 }
 
 type DeleteAiSummaryResponse {
@@ -217,6 +218,7 @@ type Query {
   yearlyTopBooks(input: GetYearlyTopBooksInput!): [YearlyTopBookResponse!]!
   userImage(input: GetUserImageInput!): String!
   isNameAvailable(input: CheckNameAvailableInput!): Boolean!
+  mySuiAddress: String
   aiSummaryUsage: Int!
   templateBooks: [TemplateBookResponse!]!
   followInfo(input: GetFollowInfoInput!): FollowInfoResponse!
@@ -229,6 +231,7 @@ type Query {
   topReaders(limit: Int): [TopReaderItem!]!
   myPurchasedBookIds: [Int!]!
   purchasedBookMemo(input: GetPurchasedBookMemoInput!): String
+  bookPaymentRecipient(input: GetBookPaymentRecipientInput!): String
 }
 
 input GetCommentsInput {
@@ -289,6 +292,10 @@ input GetPurchasedBookMemoInput {
   bookId: Int!
 }
 
+input GetBookPaymentRecipientInput {
+  bookId: Int!
+}
+
 type Mutation {
   createSheet(input: CreateSheetInput!): SheetResponse!
   updateSheet(input: UpdateSheetInput!): SheetResponse!
@@ -301,6 +308,7 @@ type Mutation {
   upsertYearlyTopBook(input: UpsertYearlyTopBookInput!): Boolean!
   deleteYearlyTopBook(input: DeleteYearlyTopBookInput!): Boolean!
   updateUserName(input: UpdateUserNameInput!): UserResponse!
+  updateSuiAddress(input: UpdateSuiAddressInput!): UserResponse!
   deleteUser: Boolean!
   saveAiSummary(input: SaveAiSummaryInput!): Boolean!
   deleteAiSummary(input: DeleteAiSummaryInput!): DeleteAiSummaryResponse!
@@ -380,6 +388,10 @@ input DeleteYearlyTopBookInput {
 
 input UpdateUserNameInput {
   name: String!
+}
+
+input UpdateSuiAddressInput {
+  suiAddress: String!
 }
 
 input SaveAiSummaryInput {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -191,6 +191,17 @@ type TopReaderItem {
   bookCount: Int!
 }
 
+type PurchaseResponse {
+  id: ID!
+  bookId: Int!
+  txDigest: String!
+  network: String!
+  amount: String!
+  senderAddress: String!
+  recipientAddress: String!
+  created: DateTime!
+}
+
 type Query {
   sheets: [SheetResponse!]!
   comments(input: GetCommentsInput!): CommentResponse!
@@ -216,6 +227,8 @@ type Query {
   unreadNotificationCount: Int!
   popularBooks(limit: Int): [PopularBookItem!]!
   topReaders(limit: Int): [TopReaderItem!]!
+  myPurchasedBookIds: [Int!]!
+  purchasedBookMemo(input: GetPurchasedBookMemoInput!): String
 }
 
 input GetCommentsInput {
@@ -272,6 +285,10 @@ input GetNotificationsInput {
   offset: Int!
 }
 
+input GetPurchasedBookMemoInput {
+  bookId: Int!
+}
+
 type Mutation {
   createSheet(input: CreateSheetInput!): SheetResponse!
   updateSheet(input: UpdateSheetInput!): SheetResponse!
@@ -294,6 +311,7 @@ type Mutation {
   likeBook(input: LikeBookInput!): Int!
   unlikeBook(input: LikeBookInput!): Int!
   markNotificationsRead: Boolean!
+  createPurchase(input: CreatePurchaseInput!): PurchaseResponse!
 }
 
 input CreateSheetInput {
@@ -396,4 +414,11 @@ input FollowUserInput {
 
 input LikeBookInput {
   bookId: Int!
+}
+
+input CreatePurchaseInput {
+  bookId: Int!
+  txDigest: String!
+  senderAddress: String!
+  network: String!
 }

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -44,6 +44,16 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 
+# Sui 決済（ブロックチェーン決済）
+# 'true' で Sui 決済ボタンを有効化（送金先アドレスの設定も必要）
+NEXT_PUBLIC_ENABLE_SUI_PAYMENT=false
+# 決済対象ネットワーク: mainnet | testnet | devnet | localnet
+NEXT_PUBLIC_SUI_NETWORK=testnet
+# 送金先（受取）アドレス
+NEXT_PUBLIC_SUI_RECIPIENT_ADDRESS=
+# 決済金額（MIST 単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI）
+NEXT_PUBLIC_SUI_PAYMENT_AMOUNT_MIST=10000000
+
 # Tiktoken(トークン数取得のエンドポイント)
 TIKTOKEN_URL=
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -45,12 +45,11 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 
 # Sui 決済（ブロックチェーン決済）
-# 'true' で Sui 決済ボタンを有効化（送金先アドレスの設定も必要）
+# 'true' で Sui 決済機能を有効化
+# ※ 送金先は本の所有者が設定ページで登録した受取アドレスを使用する（グローバル設定は不要）
 NEXT_PUBLIC_ENABLE_SUI_PAYMENT=false
 # 決済対象ネットワーク: mainnet | testnet | devnet | localnet
 NEXT_PUBLIC_SUI_NETWORK=testnet
-# 送金先（受取）アドレス
-NEXT_PUBLIC_SUI_RECIPIENT_ADDRESS=
 # 決済金額（MIST 単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI）
 NEXT_PUBLIC_SUI_PAYMENT_AMOUNT_MIST=10000000
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,11 +29,14 @@
     "@edge-runtime/cookies": "^4.1.1",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mysten/dapp-kit": "^0.15.0",
+    "@mysten/sui": "1.28.1",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.2.0",
     "@react-email/components": "0.0.10",
     "@stripe/react-stripe-js": "^2.4.0",
     "@stripe/stripe-js": "^2.2.0",
+    "@tanstack/react-query": "^5.51.0",
     "@tiptap/extension-paragraph": "2.27.2",
     "@vercel/analytics": "^1.2.2",
     "@vercel/blob": "^0.13.0",
@@ -77,7 +80,7 @@
     "sharp": "^0.34.1",
     "stripe": "^14.5.0",
     "swr": "^2.2.5",
-    "typescript": "^4.5.4"
+    "typescript": "^5.7.3"
   },
   "devDependencies": {
     "@kidoku/eslint-config": "workspace:*",
@@ -86,7 +89,7 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@types/jest": "^29.5.12",
-    "@types/node": "^17.0.8",
+    "@types/node": "^22.10.7",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
     "autoprefixer": "^10.4.13",

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -79,6 +79,7 @@ model User {
   emailVerified    DateTime?        @map("email_verified")
   image            String?
   admin            Boolean          @default(false)
+  suiAddress       String?          @map("sui_address") @db.VarChar(80)
   accounts         Account[]
   sessions         Session[]
   sheets           sheets[]

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -40,6 +40,7 @@ model books {
   user             User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   yearly_top_books YearlyTopBook[]
   likes            Like[]
+  purchases        Purchase[]
 }
 
 model Account {
@@ -90,6 +91,7 @@ model User {
   likes              Like[]
   notifications      Notification[] @relation("notificationUser")
   actorNotifications Notification[] @relation("notificationActor")
+  purchases          Purchase[]
 
   @@map("users")
 }
@@ -155,6 +157,24 @@ model Like {
   @@unique([userId, bookId], map: "uniq_user_book")
   @@index([bookId])
   @@map("likes")
+}
+
+model Purchase {
+  id               Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId           String   @map("user_id")
+  bookId           Int      @map("book_id")
+  txDigest         String   @unique @map("tx_digest") @db.VarChar(120)
+  network          String   @default("testnet") @db.VarChar(20)
+  amount           String   @db.VarChar(40)
+  senderAddress    String   @map("sender_address") @db.VarChar(80)
+  recipientAddress String   @map("recipient_address") @db.VarChar(80)
+  created          DateTime @default(now()) @db.DateTime(0)
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book             books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, bookId], map: "uniq_user_book_purchase")
+  @@index([bookId])
+  @@map("purchases")
 }
 
 model Notification {

--- a/apps/web/src/components/form/SuiCheckoutModal.tsx
+++ b/apps/web/src/components/form/SuiCheckoutModal.tsx
@@ -19,6 +19,7 @@ import {
   suiPaymentAmountLabel,
 } from '@/libs/sui/config'
 import { createPurchaseMutation } from '@/features/purchase/api'
+import { SuiLogo } from '@/components/icon/SuiLogo'
 
 // dapp-kit が要求する react-query クライアント（このモーダル内でのみ使用）
 const queryClient = new QueryClient()
@@ -119,36 +120,57 @@ const SuiCheckoutForm: React.FC<FormProps> = ({
   const isProcessing = status === 'paying' || status === 'recording'
 
   return (
-    <div className="flex flex-col items-center gap-4">
-      <h2 className="text-lg font-bold">Sui で書籍を購入</h2>
-      <p className="text-sm text-gray-600">
-        メモの閲覧には {suiPaymentAmountLabel} の支払いが必要です
-        <br />
-        <span className="text-xs text-gray-400">
-          ネットワーク: {suiNetwork}
-        </span>
-      </p>
+    <div className="flex flex-col items-center gap-5">
+      {/* ヘッダー: グラデーション + 水滴ロゴ */}
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-[#4da2ff] to-[#0571e6] shadow-lg shadow-sky-500/40 ring-1 ring-white/30">
+          <SuiLogo size={28} className="text-white" />
+        </div>
+        <h2 className="text-lg font-bold text-gray-800">Sui で書籍を購入</h2>
+      </div>
 
-      <ConnectButton />
+      {/* 金額カード */}
+      <div className="w-full rounded-xl border border-sky-100 bg-sky-50/60 px-4 py-3 text-center">
+        <p className="text-xs text-gray-500">お支払い金額</p>
+        <p className="bg-gradient-to-r from-[#4da2ff] to-[#0571e6] bg-clip-text text-2xl font-extrabold tabular-nums text-transparent">
+          {suiPaymentAmountLabel}
+        </p>
+        <span className="mt-1 inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-sky-600 ring-1 ring-sky-200">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+          {suiNetwork}
+        </span>
+      </div>
+
+      <div className="sui-connect-wrap w-full [&_button]:!w-full [&_button]:!justify-center [&_button]:!rounded-full">
+        <ConnectButton />
+      </div>
 
       {account && status !== 'success' && (
         <button
           onClick={handlePay}
           disabled={isProcessing}
-          className="rounded-md bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+          className="relative inline-flex w-full items-center justify-center gap-2 overflow-hidden rounded-full bg-gradient-to-r from-[#4da2ff] via-[#3b82f6] to-[#0571e6] px-6 py-3 font-semibold text-white shadow-lg shadow-sky-500/30 ring-1 ring-inset ring-white/25 transition-all duration-200 hover:shadow-sky-400/50 hover:brightness-110 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {status === 'paying'
-            ? '署名を待っています...'
-            : status === 'recording'
-              ? '購入を記録中...'
-              : `${suiPaymentAmountLabel} を支払う`}
+          {isProcessing ? (
+            <>
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+              {status === 'paying'
+                ? 'ウォレットで署名中...'
+                : '購入を記録中...'}
+            </>
+          ) : (
+            <>
+              <SuiLogo size={16} className="text-white" />
+              {suiPaymentAmountLabel} を支払う
+            </>
+          )}
         </button>
       )}
 
       {status === 'success' && (
         <button
           onClick={onClose}
-          className="rounded-md bg-green-600 px-6 py-2 text-white hover:bg-green-700"
+          className="inline-flex w-full items-center justify-center rounded-full bg-emerald-500 px-6 py-3 font-semibold text-white shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-600"
         >
           閉じる
         </button>
@@ -156,11 +178,16 @@ const SuiCheckoutForm: React.FC<FormProps> = ({
 
       {message && (
         <p
-          className={`text-sm ${status === 'error' ? 'text-red-500' : 'text-green-600'}`}
+          className={`text-center text-sm ${status === 'error' ? 'text-red-500' : 'text-emerald-600'}`}
         >
           {message}
         </p>
       )}
+
+      <p className="flex items-center gap-1 text-[11px] text-gray-400">
+        <SuiLogo size={11} className="text-sky-400" />
+        Powered by Sui blockchain
+      </p>
     </div>
   )
 }

--- a/apps/web/src/components/form/SuiCheckoutModal.tsx
+++ b/apps/web/src/components/form/SuiCheckoutModal.tsx
@@ -14,7 +14,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import '@mysten/dapp-kit/dist/index.css'
 import {
   suiNetwork,
-  suiRecipientAddress,
   suiPaymentAmountMist,
   suiPaymentAmountLabel,
 } from '@/libs/sui/config'
@@ -35,6 +34,8 @@ interface Props {
   open: boolean
   onClose: () => void
   bookId: number
+  /** 送金先（本の所有者の受取アドレス） */
+  recipientAddress: string
   onPurchased?: () => void
 }
 
@@ -42,6 +43,7 @@ export const SuiCheckoutModal: React.FC<Props> = ({
   open,
   onClose,
   bookId,
+  recipientAddress,
   onPurchased,
 }) => {
   if (!open) return null
@@ -52,6 +54,7 @@ export const SuiCheckoutModal: React.FC<Props> = ({
           <WalletProvider autoConnect>
             <SuiCheckoutForm
               bookId={bookId}
+              recipientAddress={recipientAddress}
               onPurchased={onPurchased}
               onClose={onClose}
             />
@@ -66,12 +69,14 @@ type PaymentStatus = 'idle' | 'paying' | 'recording' | 'success' | 'error'
 
 interface FormProps {
   bookId: number
+  recipientAddress: string
   onPurchased?: () => void
   onClose: () => void
 }
 
 const SuiCheckoutForm: React.FC<FormProps> = ({
   bookId,
+  recipientAddress,
   onPurchased,
   onClose,
 }) => {
@@ -89,7 +94,7 @@ const SuiCheckoutForm: React.FC<FormProps> = ({
       setStatus('paying')
       const tx = new Transaction()
       const [coin] = tx.splitCoins(tx.gas, [suiPaymentAmountMist])
-      tx.transferObjects([coin], suiRecipientAddress)
+      tx.transferObjects([coin], recipientAddress)
 
       const result = await signAndExecute({ transaction: tx })
 

--- a/apps/web/src/components/form/SuiCheckoutModal.tsx
+++ b/apps/web/src/components/form/SuiCheckoutModal.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { Modal } from '../layout/Modal'
+import { useMutation } from '@apollo/client'
+import {
+  SuiClientProvider,
+  WalletProvider,
+  ConnectButton,
+  useCurrentAccount,
+  useSignAndExecuteTransaction,
+} from '@mysten/dapp-kit'
+import { getFullnodeUrl } from '@mysten/sui/client'
+import { Transaction } from '@mysten/sui/transactions'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import '@mysten/dapp-kit/dist/index.css'
+import {
+  suiNetwork,
+  suiRecipientAddress,
+  suiPaymentAmountMist,
+  suiPaymentAmountLabel,
+} from '@/libs/sui/config'
+import { createPurchaseMutation } from '@/features/purchase/api'
+
+// dapp-kit が要求する react-query クライアント（このモーダル内でのみ使用）
+const queryClient = new QueryClient()
+
+const networks = {
+  mainnet: { url: getFullnodeUrl('mainnet') },
+  testnet: { url: getFullnodeUrl('testnet') },
+  devnet: { url: getFullnodeUrl('devnet') },
+  localnet: { url: getFullnodeUrl('localnet') },
+}
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  bookId: number
+  onPurchased?: () => void
+}
+
+export const SuiCheckoutModal: React.FC<Props> = ({
+  open,
+  onClose,
+  bookId,
+  onPurchased,
+}) => {
+  if (!open) return null
+  return (
+    <Modal open={open} onClose={onClose} className="min-w-1/2 bg-white p-6">
+      <QueryClientProvider client={queryClient}>
+        <SuiClientProvider networks={networks} defaultNetwork={suiNetwork}>
+          <WalletProvider autoConnect>
+            <SuiCheckoutForm
+              bookId={bookId}
+              onPurchased={onPurchased}
+              onClose={onClose}
+            />
+          </WalletProvider>
+        </SuiClientProvider>
+      </QueryClientProvider>
+    </Modal>
+  )
+}
+
+type PaymentStatus = 'idle' | 'paying' | 'recording' | 'success' | 'error'
+
+interface FormProps {
+  bookId: number
+  onPurchased?: () => void
+  onClose: () => void
+}
+
+const SuiCheckoutForm: React.FC<FormProps> = ({
+  bookId,
+  onPurchased,
+  onClose,
+}) => {
+  const account = useCurrentAccount()
+  const { mutateAsync: signAndExecute } = useSignAndExecuteTransaction()
+  const [createPurchase] = useMutation(createPurchaseMutation)
+  const [status, setStatus] = useState<PaymentStatus>('idle')
+  const [message, setMessage] = useState('')
+
+  const handlePay = async () => {
+    if (!account) return
+    setMessage('')
+    try {
+      // SUI を送金先へ転送するトランザクションを構築
+      setStatus('paying')
+      const tx = new Transaction()
+      const [coin] = tx.splitCoins(tx.gas, [suiPaymentAmountMist])
+      tx.transferObjects([coin], suiRecipientAddress)
+
+      const result = await signAndExecute({ transaction: tx })
+
+      // バックエンドで購入を検証・記録する
+      setStatus('recording')
+      await createPurchase({
+        variables: {
+          input: {
+            bookId,
+            txDigest: result.digest,
+            senderAddress: account.address,
+            network: suiNetwork,
+          },
+        },
+      })
+
+      setStatus('success')
+      setMessage('購入が完了しました！')
+      onPurchased?.()
+    } catch (e) {
+      setStatus('error')
+      const msg =
+        e instanceof Error ? e.message : '決済中にエラーが発生しました'
+      setMessage(msg)
+    }
+  }
+
+  const isProcessing = status === 'paying' || status === 'recording'
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <h2 className="text-lg font-bold">Sui で書籍を購入</h2>
+      <p className="text-sm text-gray-600">
+        メモの閲覧には {suiPaymentAmountLabel} の支払いが必要です
+        <br />
+        <span className="text-xs text-gray-400">
+          ネットワーク: {suiNetwork}
+        </span>
+      </p>
+
+      <ConnectButton />
+
+      {account && status !== 'success' && (
+        <button
+          onClick={handlePay}
+          disabled={isProcessing}
+          className="rounded-md bg-blue-600 px-6 py-2 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {status === 'paying'
+            ? '署名を待っています...'
+            : status === 'recording'
+              ? '購入を記録中...'
+              : `${suiPaymentAmountLabel} を支払う`}
+        </button>
+      )}
+
+      {status === 'success' && (
+        <button
+          onClick={onClose}
+          className="rounded-md bg-green-600 px-6 py-2 text-white hover:bg-green-700"
+        >
+          閉じる
+        </button>
+      )}
+
+      {message && (
+        <p
+          className={`text-sm ${status === 'error' ? 'text-red-500' : 'text-green-600'}`}
+        >
+          {message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/icon/SuiLogo.tsx
+++ b/apps/web/src/components/icon/SuiLogo.tsx
@@ -1,0 +1,33 @@
+interface Props {
+  size?: number
+  className?: string
+}
+
+/**
+ * Sui のシンボル（水滴）を模したロゴアイコン。
+ * fill は currentColor を使用するため、文字色クラスで色を制御できる。
+ */
+export const SuiLogo: React.FC<Props> = ({ size = 18, className = '' }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden="true"
+  >
+    <path
+      d="M12 2.25c2.2 3.06 7.05 7.66 7.05 12.6A7.05 7.05 0 1 1 4.95 14.85C4.95 9.91 9.8 5.31 12 2.25Z"
+      fill="currentColor"
+    />
+    <path
+      d="M9.2 12.1c-.9 1.27-1.15 2.86-.5 4.3.66 1.46 2.06 2.4 3.6 2.5"
+      stroke="white"
+      strokeOpacity="0.6"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      fill="none"
+    />
+  </svg>
+)

--- a/apps/web/src/features/purchase/api/index.ts
+++ b/apps/web/src/features/purchase/api/index.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client'
+
+export const createPurchaseMutation = gql`
+  mutation CreatePurchase($input: CreatePurchaseInput!) {
+    createPurchase(input: $input) {
+      id
+      bookId
+      txDigest
+      network
+      amount
+      created
+    }
+  }
+`
+
+export const myPurchasedBookIdsQuery = gql`
+  query MyPurchasedBookIds {
+    myPurchasedBookIds
+  }
+`
+
+export const purchasedBookMemoQuery = gql`
+  query PurchasedBookMemo($input: GetPurchasedBookMemoInput!) {
+    purchasedBookMemo(input: $input)
+  }
+`

--- a/apps/web/src/features/purchase/api/index.ts
+++ b/apps/web/src/features/purchase/api/index.ts
@@ -24,3 +24,9 @@ export const purchasedBookMemoQuery = gql`
     purchasedBookMemo(input: $input)
   }
 `
+
+export const bookPaymentRecipientQuery = gql`
+  query BookPaymentRecipient($input: GetBookPaymentRecipientInput!) {
+    bookPaymentRecipient(input: $input)
+  }
+`

--- a/apps/web/src/features/settings/ProfilePage.tsx
+++ b/apps/web/src/features/settings/ProfilePage.tsx
@@ -1,12 +1,15 @@
 import { useRef, useState } from 'react'
 import { Container } from '@/components/layout/Container'
 import { NextSeo } from 'next-seo'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useLazyQuery, useMutation, useQuery } from '@apollo/client'
 import {
   isNameAvailableQuery,
   updateUserNameMutation,
   deleteUserMutation,
+  mySuiAddressQuery,
+  updateSuiAddressMutation,
 } from '@/features/user/api'
+import { SuiLogo } from '@/components/icon/SuiLogo'
 
 interface Props {
   name: string
@@ -21,6 +24,38 @@ export const ProfilePage: React.FC<Props> = ({ name, image }) => {
   const [checkNameAvailable] = useLazyQuery(isNameAvailableQuery)
   const [updateUserName] = useMutation(updateUserNameMutation)
   const [deleteUser] = useMutation(deleteUserMutation)
+
+  // Sui 受取アドレス
+  const [suiAddress, setSuiAddress] = useState('')
+  const [suiError, setSuiError] = useState('')
+  const [suiSaved, setSuiSaved] = useState(false)
+  const savedSuiRef = useRef('')
+  useQuery(mySuiAddressQuery, {
+    fetchPolicy: 'network-only',
+    onCompleted: (data) => {
+      const addr = data?.mySuiAddress ?? ''
+      setSuiAddress(addr)
+      savedSuiRef.current = addr
+    },
+  })
+  const [updateSuiAddress] = useMutation(updateSuiAddressMutation)
+
+  const onChangeSui = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim()
+    setSuiAddress(value)
+    setSuiSaved(false)
+    setSuiError(
+      value === '' || /^0x[0-9a-fA-F]{1,64}$/.test(value)
+        ? ''
+        : '0x で始まる正しい Sui アドレスを入力してください'
+    )
+  }
+  const onBlurSui = async () => {
+    if (suiError || suiAddress === savedSuiRef.current) return
+    await updateSuiAddress({ variables: { input: { suiAddress } } })
+    savedSuiRef.current = suiAddress
+    setSuiSaved(true)
+  }
 
   const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value
@@ -86,6 +121,30 @@ export const ProfilePage: React.FC<Props> = ({ name, image }) => {
               {saved && <span className="text-green-600">保存しました</span>}
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* Sui 受取アドレス */}
+      <section className="mb-6 rounded-lg border border-slate-200 bg-white p-6">
+        <div className="mb-1 flex items-center gap-2">
+          <SuiLogo size={16} className="text-sky-500" />
+          <h3 className="text-sm font-bold text-gray-700">Sui 受取アドレス</h3>
+        </div>
+        <p className="mb-4 text-xs text-gray-500">
+          有料メモが購入されたときに SUI を受け取るウォレットアドレスです。
+          未設定の場合、あなたの本は Sui で購入できません。
+        </p>
+        <input
+          value={suiAddress}
+          placeholder="0x..."
+          spellCheck={false}
+          className="w-full rounded-md border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-sm outline-none transition focus:border-slate-400 focus:bg-white"
+          onChange={onChangeSui}
+          onBlur={onBlurSui}
+        />
+        <div className="mt-1 h-4 text-xs">
+          {suiError && <span className="text-red-600">{suiError}</span>}
+          {suiSaved && <span className="text-green-600">保存しました</span>}
         </div>
       </section>
 

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -6,12 +6,6 @@ import { AiFillLock } from 'react-icons/ai'
 import { useIsBookOwner } from '@/hooks/useIsBookOwner'
 import { MdEdit } from 'react-icons/md'
 
-// Stripeが設定されている場合のみCheckoutModalを読み込む（サンドボックス環境対応）
-const CheckoutModal = dynamic(
-  () =>
-    import('@/components/form/CheckoutModal').then((mod) => mod.CheckoutModal),
-  { ssr: false }
-)
 // Sui決済モーダル（ウォレット連携を含むため動的読み込み）
 const SuiCheckoutModal = dynamic(
   () =>
@@ -32,6 +26,7 @@ import { LikeButton } from '@/features/social/components/LikeButton'
 import { useCachedSession } from '@/hooks/useCachedSession'
 import { isSuiPaymentEnabled, suiPaymentAmountLabel } from '@/libs/sui/config'
 import { purchasedBookMemoQuery } from '@/features/purchase/api'
+import { SuiLogo } from '@/components/icon/SuiLogo'
 
 interface Props {
   book: Book
@@ -42,7 +37,6 @@ interface Props {
 export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
   const isMine = useIsBookOwner(book)
   const { status } = useCachedSession()
-  const [open, setOpen] = useState(false)
   const [suiOpen, setSuiOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
@@ -203,20 +197,20 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
                   {process.env.NEXT_PUBLIC_FLAG_KIDOKU_1 === 'true' &&
                     book.isPurchasable && (
                       <div className="mt-4 flex flex-col items-center gap-2">
-                        {process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY && (
-                          <button
-                            className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
-                            onClick={() => setOpen(true)}
-                          >
-                            メモを見る（カード決済）
-                          </button>
-                        )}
                         {isSuiPaymentEnabled && (
                           <button
-                            className="rounded bg-sky-600 px-4 py-2 text-white hover:bg-sky-700"
                             onClick={() => setSuiOpen(true)}
+                            className="group relative inline-flex items-center gap-2.5 overflow-hidden rounded-full bg-gradient-to-r from-[#4da2ff] via-[#3b82f6] to-[#0571e6] px-5 py-2.5 font-semibold text-white shadow-lg shadow-sky-500/30 ring-1 ring-inset ring-white/25 transition-all duration-200 hover:shadow-sky-400/50 hover:brightness-110 active:scale-[0.98]"
                           >
-                            Suiで購入（{suiPaymentAmountLabel}）
+                            {/* ホバー時に走る光沢 */}
+                            <span className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/25 to-transparent transition-transform duration-700 group-hover:translate-x-full" />
+                            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white/20 ring-1 ring-white/30">
+                              <SuiLogo size={13} className="text-white" />
+                            </span>
+                            <span>Suiで購入</span>
+                            <span className="rounded-full bg-white/20 px-2 py-0.5 text-xs font-bold tabular-nums ring-1 ring-white/20">
+                              {suiPaymentAmountLabel}
+                            </span>
                           </button>
                         )}
                       </div>
@@ -226,15 +220,6 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
           </div>
         </div>
       </div>
-
-      {process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY && (
-        <CheckoutModal
-          open={open}
-          onClose={() => setOpen(false)}
-          returnUrl={returnUrl()}
-          purchaseText="書籍を購入"
-        />
-      )}
 
       {isSuiPaymentEnabled && (
         <SuiCheckoutModal

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -12,6 +12,14 @@ const CheckoutModal = dynamic(
     import('@/components/form/CheckoutModal').then((mod) => mod.CheckoutModal),
   { ssr: false }
 )
+// Sui決済モーダル（ウォレット連携を含むため動的読み込み）
+const SuiCheckoutModal = dynamic(
+  () =>
+    import('@/components/form/SuiCheckoutModal').then(
+      (mod) => mod.SuiCheckoutModal
+    ),
+  { ssr: false }
+)
 import { Loading } from '@/components/icon/Loading'
 import { Tooltip } from 'react-tooltip'
 import { Memo } from './Memo'
@@ -22,6 +30,8 @@ import { useQuery } from '@apollo/client'
 import { myLikedBookIdsQuery } from '@/features/social/api'
 import { LikeButton } from '@/features/social/components/LikeButton'
 import { useCachedSession } from '@/hooks/useCachedSession'
+import { isSuiPaymentEnabled, suiPaymentAmountLabel } from '@/libs/sui/config'
+import { purchasedBookMemoQuery } from '@/features/purchase/api'
 
 interface Props {
   book: Book
@@ -33,6 +43,7 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
   const isMine = useIsBookOwner(book)
   const { status } = useCachedSession()
   const [open, setOpen] = useState(false)
+  const [suiOpen, setSuiOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
   // ログイン中はいいね済みの本IDを取得し、初期状態を反映する
@@ -40,6 +51,17 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
     skip: status !== 'authenticated',
   })
   const likedBookIds: number[] = likedData?.myLikedBookIds ?? []
+
+  // 購入済みの場合は解放されたメモ本文を取得する（非所有者・非公開・購入可能なときのみ）
+  const canPurchase = !isMine && !book.isPublicMemo && book.isPurchasable
+  const { data: memoData, refetch: refetchMemo } = useQuery(
+    purchasedBookMemoQuery,
+    {
+      variables: { input: { bookId: Number(book.id) } },
+      skip: status !== 'authenticated' || !canPurchase,
+    }
+  )
+  const unlockedMemo: string | null | undefined = memoData?.purchasedBookMemo
 
   const returnUrl = () => {
     return `${process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'}/books/${book.id}`
@@ -163,23 +185,44 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
               </div>
             )}
 
-            {!isMine && !book.isPublicMemo && (
-              <div className="rounded-lg bg-gray-100 p-8 text-center">
-                <AiFillLock className="mx-auto mb-2 text-gray-400" size={24} />
-                <p className="text-gray-600">
-                  このメモは非公開に設定されています
-                </p>
-                {process.env.NEXT_PUBLIC_FLAG_KIDOKU_1 === 'true' &&
-                  book.isPurchasable && (
-                    <button
-                      className="mt-4 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
-                      onClick={() => setOpen(true)}
-                    >
-                      メモを見る（有料）
-                    </button>
-                  )}
-              </div>
-            )}
+            {!isMine &&
+              !book.isPublicMemo &&
+              (unlockedMemo !== null && unlockedMemo !== undefined ? (
+                <div className="rounded-lg bg-gray-50 p-4">
+                  <Memo memo={unlockedMemo} />
+                </div>
+              ) : (
+                <div className="rounded-lg bg-gray-100 p-8 text-center">
+                  <AiFillLock
+                    className="mx-auto mb-2 text-gray-400"
+                    size={24}
+                  />
+                  <p className="text-gray-600">
+                    このメモは非公開に設定されています
+                  </p>
+                  {process.env.NEXT_PUBLIC_FLAG_KIDOKU_1 === 'true' &&
+                    book.isPurchasable && (
+                      <div className="mt-4 flex flex-col items-center gap-2">
+                        {process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY && (
+                          <button
+                            className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+                            onClick={() => setOpen(true)}
+                          >
+                            メモを見る（カード決済）
+                          </button>
+                        )}
+                        {isSuiPaymentEnabled && (
+                          <button
+                            className="rounded bg-sky-600 px-4 py-2 text-white hover:bg-sky-700"
+                            onClick={() => setSuiOpen(true)}
+                          >
+                            Suiで購入（{suiPaymentAmountLabel}）
+                          </button>
+                        )}
+                      </div>
+                    )}
+                </div>
+              ))}
           </div>
         </div>
       </div>
@@ -190,6 +233,18 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
           onClose={() => setOpen(false)}
           returnUrl={returnUrl()}
           purchaseText="書籍を購入"
+        />
+      )}
+
+      {isSuiPaymentEnabled && (
+        <SuiCheckoutModal
+          open={suiOpen}
+          onClose={() => setSuiOpen(false)}
+          bookId={Number(book.id)}
+          onPurchased={() => {
+            refetchMemo()
+            setSuiOpen(false)
+          }}
         />
       )}
     </div>

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -25,7 +25,10 @@ import { myLikedBookIdsQuery } from '@/features/social/api'
 import { LikeButton } from '@/features/social/components/LikeButton'
 import { useCachedSession } from '@/hooks/useCachedSession'
 import { isSuiPaymentEnabled, suiPaymentAmountLabel } from '@/libs/sui/config'
-import { purchasedBookMemoQuery } from '@/features/purchase/api'
+import {
+  purchasedBookMemoQuery,
+  bookPaymentRecipientQuery,
+} from '@/features/purchase/api'
 import { SuiLogo } from '@/components/icon/SuiLogo'
 
 interface Props {
@@ -56,6 +59,14 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
     }
   )
   const unlockedMemo: string | null | undefined = memoData?.purchasedBookMemo
+
+  // 本の所有者が登録した Sui 受取アドレス（未登録ならボタンを出さない）
+  const { data: recipientData } = useQuery(bookPaymentRecipientQuery, {
+    variables: { input: { bookId: Number(book.id) } },
+    skip: status !== 'authenticated' || !isSuiPaymentEnabled || !canPurchase,
+  })
+  const suiRecipient: string | null | undefined =
+    recipientData?.bookPaymentRecipient
 
   const returnUrl = () => {
     return `${process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'}/books/${book.id}`
@@ -197,7 +208,7 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
                   {process.env.NEXT_PUBLIC_FLAG_KIDOKU_1 === 'true' &&
                     book.isPurchasable && (
                       <div className="mt-4 flex flex-col items-center gap-2">
-                        {isSuiPaymentEnabled && (
+                        {isSuiPaymentEnabled && suiRecipient && (
                           <button
                             onClick={() => setSuiOpen(true)}
                             className="group relative inline-flex items-center gap-2.5 overflow-hidden rounded-full bg-gradient-to-r from-[#4da2ff] via-[#3b82f6] to-[#0571e6] px-5 py-2.5 font-semibold text-white shadow-lg shadow-sky-500/30 ring-1 ring-inset ring-white/25 transition-all duration-200 hover:shadow-sky-400/50 hover:brightness-110 active:scale-[0.98]"
@@ -221,11 +232,12 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
         </div>
       </div>
 
-      {isSuiPaymentEnabled && (
+      {isSuiPaymentEnabled && suiRecipient && (
         <SuiCheckoutModal
           open={suiOpen}
           onClose={() => setSuiOpen(false)}
           bookId={Number(book.id)}
+          recipientAddress={suiRecipient}
           onPurchased={() => {
             refetchMemo()
             setSuiOpen(false)

--- a/apps/web/src/features/user/api/mutations.ts
+++ b/apps/web/src/features/user/api/mutations.ts
@@ -8,6 +8,15 @@ export const updateUserNameMutation = gql`
   }
 `
 
+export const updateSuiAddressMutation = gql`
+  mutation UpdateSuiAddress($input: UpdateSuiAddressInput!) {
+    updateSuiAddress(input: $input) {
+      name
+      suiAddress
+    }
+  }
+`
+
 export const deleteUserMutation = gql`
   mutation DeleteUser {
     deleteUser

--- a/apps/web/src/features/user/api/queries.ts
+++ b/apps/web/src/features/user/api/queries.ts
@@ -11,3 +11,9 @@ export const isNameAvailableQuery = gql`
     isNameAvailable(input: $input)
   }
 `
+
+export const mySuiAddressQuery = gql`
+  query MySuiAddress {
+    mySuiAddress
+  }
+`

--- a/apps/web/src/libs/sharp/bufferToWebp.ts
+++ b/apps/web/src/libs/sharp/bufferToWebp.ts
@@ -1,5 +1,16 @@
 import sharp from 'sharp'
 
-export const bufferToWebp = async (imageBuffer: Buffer | ArrayBuffer) => {
-  return await sharp(imageBuffer).resize(158).webp({ quality: 90 }).toBuffer()
+export const bufferToWebp = async (
+  imageBuffer: Buffer | ArrayBuffer
+): Promise<ArrayBuffer> => {
+  const webp = await sharp(imageBuffer)
+    .resize(158)
+    .webp({ quality: 90 })
+    .toBuffer()
+  // Node の Buffer をそのまま渡すと @vercel/blob の put() の body 型と不整合になるため
+  // ArrayBuffer に変換して返す
+  return webp.buffer.slice(
+    webp.byteOffset,
+    webp.byteOffset + webp.byteLength
+  ) as ArrayBuffer
 }

--- a/apps/web/src/libs/sui/config.ts
+++ b/apps/web/src/libs/sui/config.ts
@@ -1,0 +1,37 @@
+export type SuiNetwork = 'mainnet' | 'testnet' | 'devnet' | 'localnet'
+
+export const SUI_DECIMALS = 9
+
+/** 決済対象のSuiネットワーク */
+export const suiNetwork: SuiNetwork =
+  (process.env.NEXT_PUBLIC_SUI_NETWORK as SuiNetwork) || 'testnet'
+
+/** 送金先（受取）アドレス */
+export const suiRecipientAddress =
+  process.env.NEXT_PUBLIC_SUI_RECIPIENT_ADDRESS || ''
+
+/** 決済金額（MIST単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI） */
+export const suiPaymentAmountMist = BigInt(
+  process.env.NEXT_PUBLIC_SUI_PAYMENT_AMOUNT_MIST || '10000000'
+)
+
+/**
+ * Sui決済が利用可能かどうか。
+ * フラグが有効かつ送金先アドレスが設定されている場合のみ有効。
+ */
+export const isSuiPaymentEnabled =
+  process.env.NEXT_PUBLIC_ENABLE_SUI_PAYMENT === 'true' &&
+  suiRecipientAddress.length > 0
+
+/** MIST を SUI 表記の文字列に変換する */
+export const mistToSui = (mist: bigint): string => {
+  const base = BigInt(10) ** BigInt(SUI_DECIMALS)
+  const whole = mist / base
+  const frac = mist % base
+  if (frac === BigInt(0)) return whole.toString()
+  const fracStr = frac.toString().padStart(SUI_DECIMALS, '0').replace(/0+$/, '')
+  return `${whole.toString()}.${fracStr}`
+}
+
+/** 表示用の決済金額ラベル（例: "0.01 SUI"） */
+export const suiPaymentAmountLabel = `${mistToSui(suiPaymentAmountMist)} SUI`

--- a/apps/web/src/libs/sui/config.ts
+++ b/apps/web/src/libs/sui/config.ts
@@ -6,22 +6,17 @@ export const SUI_DECIMALS = 9
 export const suiNetwork: SuiNetwork =
   (process.env.NEXT_PUBLIC_SUI_NETWORK as SuiNetwork) || 'testnet'
 
-/** 送金先（受取）アドレス */
-export const suiRecipientAddress =
-  process.env.NEXT_PUBLIC_SUI_RECIPIENT_ADDRESS || ''
-
 /** 決済金額（MIST単位。1 SUI = 1_000_000_000 MIST。既定: 0.01 SUI） */
 export const suiPaymentAmountMist = BigInt(
   process.env.NEXT_PUBLIC_SUI_PAYMENT_AMOUNT_MIST || '10000000'
 )
 
 /**
- * Sui決済が利用可能かどうか。
- * フラグが有効かつ送金先アドレスが設定されている場合のみ有効。
+ * Sui決済機能が有効かどうか（機能フラグ）。
+ * 実際の送金先は本の所有者ごとの受取アドレスを別途取得する。
  */
 export const isSuiPaymentEnabled =
-  process.env.NEXT_PUBLIC_ENABLE_SUI_PAYMENT === 'true' &&
-  suiRecipientAddress.length > 0
+  process.env.NEXT_PUBLIC_ENABLE_SUI_PAYMENT === 'true'
 
 /** MIST を SUI 表記の文字列に変換する */
 export const mistToSui = (mist: bigint): string => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@as-integrations/express5':
         specifier: ^1.1.2
         version: 1.1.2(@apollo/server@5.4.0(graphql@16.12.0))(express@5.2.1)
+      '@mysten/sui':
+        specifier: ^1.18.0
+        version: 1.45.2(typescript@5.8.2)
       '@nestjs/apollo':
         specifier: ^13.1.0
         version: 13.2.4(@apollo/server@5.4.0(graphql@16.12.0))(@as-integrations/express5@1.1.2(@apollo/server@5.4.0(graphql@16.12.0))(express@5.2.1))(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(@nestjs/graphql@13.2.4(@nestjs/common@11.1.14(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.14)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2))(graphql@16.12.0)
@@ -160,6 +163,12 @@ importers:
       '@emotion/styled':
         specifier: ^11.9.3
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.79)(react@18.3.1))(@types/react@18.2.79)(react@18.3.1)
+      '@mysten/dapp-kit':
+        specifier: ^0.15.0
+        version: 0.15.7(@tanstack/react-query@5.101.0(react@18.3.1))(@types/react-dom@18.2.25)(@types/react@18.2.79)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+      '@mysten/sui':
+        specifier: 1.28.1
+        version: 1.28.1(typescript@5.8.2)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
         version: 1.0.7(@prisma/client@5.22.0(prisma@5.22.0))(next-auth@4.24.13(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -168,19 +177,22 @@ importers:
         version: 5.22.0(prisma@5.22.0)
       '@react-email/components':
         specifier: 0.0.10
-        version: 0.0.10(@types/react@18.2.79)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+        version: 0.0.10(@types/react@18.2.79)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
       '@stripe/react-stripe-js':
         specifier: ^2.4.0
         version: 2.9.0(@stripe/stripe-js@2.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@stripe/stripe-js':
         specifier: ^2.2.0
         version: 2.4.0
+      '@tanstack/react-query':
+        specifier: ^5.51.0
+        version: 5.101.0(react@18.3.1)
       '@tiptap/extension-paragraph':
         specifier: 2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       '@vercel/analytics':
         specifier: ^1.2.2
-        version: 1.6.1(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.20)(vue@3.5.28(typescript@4.9.5))
+        version: 1.6.1(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.20)(vue@3.5.28(typescript@5.8.2))
       '@vercel/blob':
         specifier: ^0.13.0
         version: 0.13.1
@@ -195,7 +207,7 @@ importers:
         version: 3.9.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ai:
         specifier: ^2.2.34
-        version: 2.2.37(react@18.3.1)(solid-js@1.9.11)(svelte@4.2.20)(vue@3.5.28(typescript@4.9.5))
+        version: 2.2.37(react@18.3.1)(solid-js@1.9.11)(svelte@4.2.20)(vue@3.5.28(typescript@5.8.2))
       axios:
         specifier: ^0.27.2
         version: 0.27.2
@@ -305,8 +317,8 @@ importers:
         specifier: ^2.2.5
         version: 2.4.0(react@18.3.1)
       typescript:
-        specifier: ^4.5.4
-        version: 4.9.5
+        specifier: ^5.7.3
+        version: 5.8.2
     devDependencies:
       '@kidoku/eslint-config':
         specifier: workspace:*
@@ -327,8 +339,8 @@ importers:
         specifier: ^29.5.12
         version: 29.5.14
       '@types/node':
-        specifier: ^17.0.8
-        version: 17.0.45
+        specifier: ^22.10.7
+        version: 22.19.11
       '@types/react':
         specifier: 18.2.79
         version: 18.2.79
@@ -343,7 +355,7 @@ importers:
         version: 9.39.3(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+        version: 29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -403,6 +415,20 @@ importers:
         version: 8.56.0(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)
 
 packages:
+
+  '@0no-co/graphql.web@1.3.2':
+    resolution: {integrity: sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -1009,11 +1035,46 @@ packages:
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@gql.tada/cli-utils@1.9.2':
+    resolution: {integrity: sha512-cVNs4v8ewLRYJfyAsaHbiAmd5Hm+zXEMvMhBksH58ZU87d6f8crsp2CQG6QtIqnJJw1q0CBWfWTZepGWNcL3QA==}
+    peerDependencies:
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
+
+  '@gql.tada/internal@1.2.1':
+    resolution: {integrity: sha512-1kPMv9KRpD6mfVwtXK+iy43U/gi4bpr4ganfhPLD0TjxpbuVJm7CtZ9wMFdwy3FjLBFN2QhwscNnL7lRPHg4vg==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@graphql-tools/merge@9.1.7':
     resolution: {integrity: sha512-Y5E1vTbTabvcXbkakdFUt4zUIzB1fyaEnVmIWN0l0GMed2gdD01TpZWLUm4RNAxpturvolrb24oGLQrBbPLSoQ==}
@@ -1446,6 +1507,41 @@ packages:
     resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
     engines: {node: '>=14.18.0'}
 
+  '@mysten/bcs@1.6.0':
+    resolution: {integrity: sha512-ydDRYdIkIFCpHCcPvAkMC91fVwumjzbTgjqds0KsphDQI3jUlH3jFG5lfYNTmV6V3pkhOiRk1fupLBcsQsiszg==}
+
+  '@mysten/bcs@1.9.2':
+    resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
+
+  '@mysten/dapp-kit@0.15.7':
+    resolution: {integrity: sha512-88mE4JFmvv5qph3KrU0l6e1Kq8dtykCf8Ta3PFINjKXU+8ya2HgmptLbKRoJvNG+v6vhb8NE6IEc0LsprDB+QQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.0.0
+      react: '*'
+
+  '@mysten/sui@1.28.1':
+    resolution: {integrity: sha512-kvrcUKiC/92N4u3Ncb8j1uLeBhCjrnTZyBjIX0zNTukFFCMbZkDYEr9IVjPrvnOEwOXZ3fpYmpmw3LB9dEU5FA==}
+    engines: {node: '>=18'}
+
+  '@mysten/sui@1.45.2':
+    resolution: {integrity: sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==}
+    engines: {node: '>=18'}
+
+  '@mysten/utils@0.0.0':
+    resolution: {integrity: sha512-KRI57Qow3E7TGqczimazwGf7+fwukdOi+6a31igSCzz0kPjAXbyK1a1gXaxeLMF8xEZ07ouW3RnsWt+EaUuHUw==}
+
+  '@mysten/utils@0.2.0':
+    resolution: {integrity: sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==}
+
+  '@mysten/wallet-standard@0.14.6':
+    resolution: {integrity: sha512-jgSOcOL48Np+Yy3dVS8MHNFMMSOjA1mIuYqTc0h5PjOmeIOkzSHHC3hsSReqg7Hcm/SBb99DvvZ3XQaVPno23Q==}
+
+  '@mysten/window-wallet-core@0.0.2':
+    resolution: {integrity: sha512-u57gHFlLYPDTK5bDeabRjkIdyLaiFVwL3bVbnBtu5WJpfFOv/KMOpIQt4820ICBG843jN35tzlulQ0nlbWCYeA==}
+
+  '@mysten/zksend@0.12.27':
+    resolution: {integrity: sha512-HRgC8RnLn24SFyq1eiB3Fq/mKQWQAoYvsMV6lPQu0dUwjlehZg7jeUJbqjC2mgV91NsY9RRnCX5kFnysdUdHew==}
+
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
     engines: {node: '>= 10'}
@@ -1754,6 +1850,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/curves@1.9.4':
+    resolution: {integrity: sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -1884,6 +1988,15 @@ packages:
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    resolution: {integrity: sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==}
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    resolution: {integrity: sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==}
+
+  '@protobuf-ts/runtime@2.11.1':
+    resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1917,6 +2030,35 @@ packages:
   '@radix-ui/primitive@1.0.0':
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-arrow@1.1.10':
+    resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.10':
+    resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.0.0':
     resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
     peerDependencies:
@@ -1940,10 +2082,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.0.0':
     resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@radix-ui/react-dialog@1.0.0':
     resolution: {integrity: sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==}
@@ -1951,16 +2111,73 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-dialog@1.1.17':
+    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.0.0':
     resolution: {integrity: sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-dismissable-layer@1.1.13':
+    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.18':
+    resolution: {integrity: sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.0.0':
     resolution: {integrity: sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@radix-ui/react-focus-scope@1.0.0':
     resolution: {integrity: sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==}
@@ -1968,10 +2185,58 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-focus-scope@1.1.10':
+    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.0.0':
     resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.18':
+    resolution: {integrity: sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.1':
+    resolution: {integrity: sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-portal@1.0.0':
     resolution: {integrity: sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==}
@@ -1979,17 +2244,69 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-portal@1.1.12':
+    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.0.0':
     resolution: {integrity: sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@1.0.0':
     resolution: {integrity: sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.13':
+    resolution: {integrity: sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-slot@1.0.0':
     resolution: {integrity: sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==}
@@ -2014,25 +2331,100 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.0.0':
     resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@radix-ui/react-use-controllable-state@1.0.0':
     resolution: {integrity: sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.0.0':
     resolution: {integrity: sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
 
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.0.0':
     resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@react-email/body@0.0.4':
     resolution: {integrity: sha512-NmHOumdmyjWvOXomqhQt06KbgRxhHrVznxQp/oWiPWes8nAJo2Y4L27aPHR9nTcs7JF7NmcJe9YSN42pswK+GQ==}
@@ -2176,6 +2568,15 @@ packages:
 
   '@scena/matrix@1.1.1':
     resolution: {integrity: sha512-JVKBhN0tm2Srl+Yt+Ywqu0oLgLcdemDQlD1OxmN9jaCTwaFPZ7tY8n6dhVgMEaR9qcR7r+kAlMXnSfNyYdE+Vg==}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@selderee/plugin-htmlparser2@0.10.0':
     resolution: {integrity: sha512-gW69MEamZ4wk1OsOq1nG1jcyhXIQcnrsX5JwixVw/9xaiav8TCyjESAruu1Rz9yyInhgBXxkNwMeygKnN2uxNA==}
@@ -2330,6 +2731,14 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -2715,9 +3124,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@17.0.45':
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-
   '@types/node@18.15.3':
     resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
 
@@ -2852,6 +3258,20 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
+  '@vanilla-extract/css@1.20.1':
+    resolution: {integrity: sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==}
+
+  '@vanilla-extract/dynamic@2.1.5':
+    resolution: {integrity: sha512-QGIFGb1qyXQkbzx6X6i3+3LMc/iv/ZMBttMBL+Wm/DetQd36KsKsFg5CtH3qy+1hCA/5w93mEIIAiL4fkM8ycw==}
+
+  '@vanilla-extract/private@1.0.9':
+    resolution: {integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==}
+
+  '@vanilla-extract/recipes@0.5.7':
+    resolution: {integrity: sha512-Fvr+htdyb6LVUu+PhH61UFPhwkjgDEk8L4Zq9oIdte42sntpKrgFy90MyTRtGwjVALmrJ0pwRUVr8UoByYeW8A==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
     peerDependencies:
@@ -2914,6 +3334,31 @@ packages:
 
   '@vue/shared@3.5.28':
     resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
+
+  '@wallet-standard/app@1.1.1':
+    resolution: {integrity: sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/base@1.1.1':
+    resolution: {integrity: sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/core@1.1.0':
+    resolution: {integrity: sha512-v2W5q/NlX1qkn2q/JOXQT//pOAdrhz7+nOcO2uiH9+a0uvreL+sdWWqkhFmMcX+HEBjaibdOQMUoIfDhOGX4XA==}
+    engines: {node: '>=16'}
+
+  '@wallet-standard/errors@0.1.2':
+    resolution: {integrity: sha512-oEzKUqJefKby6wcIvaJgrSEe/uNn/rnqkJ0P/85K+h0i5Tdo9E3L22VWq/j5K1e8hHMnZd6LgaIr8m/Wn7X/Ng==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  '@wallet-standard/features@1.1.1':
+    resolution: {integrity: sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/wallet@1.1.1':
+    resolution: {integrity: sha512-8WiRPaKk/wNNRZhB2eVhpR/JW7/aqTCMoZhgVUCujuzDmxxmGvsosMxdCG4NAdYkoyozAHCX8/xLtlWUn5mNdQ==}
+    engines: {node: '>=22'}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -3485,6 +3930,10 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -3626,6 +4075,10 @@ packages:
   commander@11.0.0:
     resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
     engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -3802,6 +4255,10 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -3952,6 +4409,9 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deep-object-diff@1.1.9:
+    resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -4714,6 +5174,12 @@ packages:
     resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
     engines: {node: '>=16'}
 
+  gql.tada@1.11.2:
+    resolution: {integrity: sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -5356,6 +5822,9 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   jotai@2.18.0:
     resolution: {integrity: sha512-XI38kGWAvtxAZ+cwHcTgJsd+kJOJGf3OfL4XYaXWZMZ7IIY8e53abpIHvtVn1eAgJ5dlgwlGFnP4psrZ/vZbtA==}
     engines: {node: '>=12.20.0'}
@@ -5726,6 +6195,9 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-query-parser@2.0.2:
+    resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -5968,6 +6440,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -5977,6 +6452,9 @@ packages:
 
   mockdate@3.0.5:
     resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
+
+  modern-ahocorasick@1.1.0:
+    resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
@@ -6025,6 +6503,10 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanostores@0.10.3:
+    resolution: {integrity: sha512-Nii8O1XqmawqSCf9o2aWqVxhKRN01+iue9/VEd1TiJCr9VT5XxgPFbF1Edl1XN6pwJcZRsl8Ki+z01yb/T/C2g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -6421,6 +6903,9 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  poseidon-lite@0.2.1:
+    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -6808,6 +7293,16 @@ packages:
     peerDependencies:
       '@types/react': 18.2.79
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': 18.2.79
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7869,11 +8364,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -8058,6 +8548,17 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  valibot@0.36.0:
+    resolution: {integrity: sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ==}
+
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -8353,6 +8854,16 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@0no-co/graphql.web@1.3.2(graphql@16.12.0)':
+    optionalDependencies:
+      graphql: 16.12.0
+
+  '@0no-co/graphqlsp@1.17.3(graphql@16.12.0)(typescript@5.8.2)':
+    dependencies:
+      '@gql.tada/internal': 1.2.1(graphql@16.12.0)(typescript@5.8.2)
+      graphql: 16.12.0
+      typescript: 5.8.2
 
   '@adobe/css-tools@4.4.4': {}
 
@@ -8992,12 +9503,42 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.5':
     dependencies:
       '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@gql.tada/cli-utils@1.9.2(@0no-co/graphqlsp@1.17.3(graphql@16.12.0)(typescript@5.8.2))(graphql@16.12.0)(typescript@5.8.2)':
+    dependencies:
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.12.0)(typescript@5.8.2)
+      '@gql.tada/internal': 1.2.1(graphql@16.12.0)(typescript@5.8.2)
+      graphql: 16.12.0
+      typescript: 5.8.2
+
+  '@gql.tada/internal@1.2.1(graphql@16.12.0)(typescript@5.8.2)':
+    dependencies:
+      '@0no-co/graphql.web': 1.3.2(graphql@16.12.0)
+      graphql: 16.12.0
+      typescript: 5.8.2
 
   '@graphql-tools/merge@9.1.7(graphql@16.12.0)':
     dependencies:
@@ -9299,41 +9840,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.19.11
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
@@ -9373,7 +9879,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -9391,7 +9897,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9529,6 +10035,119 @@ snapshots:
       fast-glob: 3.3.3
       jju: 1.4.0
       js-yaml: 4.1.1
+
+  '@mysten/bcs@1.6.0':
+    dependencies:
+      '@scure/base': 1.2.6
+
+  '@mysten/bcs@1.9.2':
+    dependencies:
+      '@mysten/utils': 0.2.0
+      '@scure/base': 1.2.6
+
+  '@mysten/dapp-kit@0.15.7(@tanstack/react-query@5.101.0(react@18.3.1))(@types/react-dom@18.2.25)(@types/react@18.2.79)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)':
+    dependencies:
+      '@mysten/sui': 1.28.1(typescript@5.8.2)
+      '@mysten/utils': 0.0.0
+      '@mysten/wallet-standard': 0.14.6(typescript@5.8.2)
+      '@mysten/zksend': 0.12.27(typescript@5.8.2)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.4(@types/react@18.2.79)(react@18.3.1)
+      '@tanstack/react-query': 5.101.0(react@18.3.1)
+      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/dynamic': 2.1.5
+      '@vanilla-extract/recipes': 0.5.7(@vanilla-extract/css@1.20.1(babel-plugin-macros@3.1.0))
+      clsx: 2.1.1
+      react: 18.3.1
+      zustand: 4.5.7(@types/react@18.2.79)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - '@types/react'
+      - '@types/react-dom'
+      - babel-plugin-macros
+      - immer
+      - react-dom
+      - typescript
+
+  '@mysten/sui@1.28.1(typescript@5.8.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
+      '@mysten/bcs': 1.6.0
+      '@mysten/utils': 0.0.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      gql.tada: 1.11.2(graphql@16.12.0)(typescript@5.8.2)
+      graphql: 16.12.0
+      poseidon-lite: 0.2.1
+      valibot: 0.36.0
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/sui@1.45.2(typescript@5.8.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.12.0)
+      '@mysten/bcs': 1.9.2
+      '@mysten/utils': 0.2.0
+      '@noble/curves': 1.9.4
+      '@noble/hashes': 1.8.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      '@scure/base': 1.2.6
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      gql.tada: 1.11.2(graphql@16.12.0)(typescript@5.8.2)
+      graphql: 16.12.0
+      poseidon-lite: 0.2.1
+      valibot: 1.4.1(typescript@5.8.2)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/utils@0.0.0':
+    dependencies:
+      '@scure/base': 1.2.6
+
+  '@mysten/utils@0.2.0':
+    dependencies:
+      '@scure/base': 1.2.6
+
+  '@mysten/wallet-standard@0.14.6(typescript@5.8.2)':
+    dependencies:
+      '@mysten/sui': 1.28.1(typescript@5.8.2)
+      '@wallet-standard/core': 1.1.0
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/window-wallet-core@0.0.2':
+    dependencies:
+      '@mysten/utils': 0.0.0
+      jose: 6.2.3
+      valibot: 0.36.0
+
+  '@mysten/zksend@0.12.27(typescript@5.8.2)':
+    dependencies:
+      '@mysten/sui': 1.28.1(typescript@5.8.2)
+      '@mysten/utils': 0.0.0
+      '@mysten/wallet-standard': 0.14.6(typescript@5.8.2)
+      '@mysten/window-wallet-core': 0.0.2
+      mitt: 3.0.1
+      nanostores: 0.10.3
+      valibot: 0.36.0
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     optional: true
@@ -9806,6 +10425,14 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
+  '@noble/curves@1.9.4':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -9951,6 +10578,17 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
 
+  '@protobuf-ts/grpcweb-transport@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@protobuf-ts/runtime-rpc@2.11.1':
+    dependencies:
+      '@protobuf-ts/runtime': 2.11.1
+
+  '@protobuf-ts/runtime@2.11.1': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -9978,6 +10616,29 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
 
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-arrow@1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-collection@1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
   '@radix-ui/react-compose-refs@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -9996,10 +10657,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.79
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-context@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
+
+  '@radix-ui/react-context@1.1.4(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   '@radix-ui/react-dialog@1.0.0(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10023,6 +10696,34 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@radix-ui/react-dialog@1.1.17(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.2.79)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.2.79)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-direction@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-dismissable-layer@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -10034,10 +10735,44 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-dropdown-menu@2.1.18(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
   '@radix-ui/react-focus-guards@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   '@radix-ui/react-focus-scope@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10048,11 +10783,73 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
   '@radix-ui/react-id@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.3.1)
       react: 18.3.1
+
+  '@radix-ui/react-id@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-menu@2.1.18(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.2.79)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-popper@1.3.1(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/rect': 1.1.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
 
   '@radix-ui/react-portal@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10060,6 +10857,16 @@ snapshots:
       '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@radix-ui/react-portal@1.1.12(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
 
   '@radix-ui/react-presence@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10069,12 +10876,47 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
   '@radix-ui/react-primitive@1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@radix-ui/react-slot': 1.0.0(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+
+  '@radix-ui/react-roving-focus@1.1.13(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
 
   '@radix-ui/react-slot@1.0.0(react@18.3.1)':
     dependencies:
@@ -10097,10 +10939,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.79
 
+  '@radix-ui/react-slot@1.3.0(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-use-callback-ref@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
 
   '@radix-ui/react-use-controllable-state@1.0.0(react@18.3.1)':
     dependencies:
@@ -10108,16 +10963,60 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
       react: 18.3.1
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.2.79)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-use-escape-keydown@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.1)
       react: 18.3.1
 
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
   '@radix-ui/react-use-layout-effect@1.0.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-rect@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.2.79)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@react-email/body@0.0.4(react@18.3.1)':
     dependencies:
@@ -10131,7 +11030,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@react-email/components@0.0.10(@types/react@18.2.79)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))':
+  '@react-email/components@0.0.10(@types/react@18.2.79)(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))':
     dependencies:
       '@react-email/body': 0.0.4(react@18.3.1)
       '@react-email/button': 0.0.11(react@18.3.1)
@@ -10148,7 +11047,7 @@ snapshots:
       '@react-email/render': 0.0.8
       '@react-email/row': 0.0.6(react@18.3.1)
       '@react-email/section': 0.0.10(react@18.3.1)
-      '@react-email/tailwind': 0.0.12(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+      '@react-email/tailwind': 0.0.12(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
       '@react-email/text': 0.0.6(react@18.3.1)
       react: 18.3.1
     transitivePeerDependencies:
@@ -10223,11 +11122,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@react-email/tailwind@0.0.12(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))':
+  '@react-email/tailwind@0.0.12(react@18.3.1)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))':
     dependencies:
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      tw-to-css: 0.0.12(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+      tw-to-css: 0.0.12(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
     transitivePeerDependencies:
       - ts-node
 
@@ -10251,6 +11150,19 @@ snapshots:
   '@scena/matrix@1.1.1':
     dependencies:
       '@daybrush/utils': 1.13.0
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@selderee/plugin-htmlparser2@0.10.0':
     dependencies:
@@ -10412,6 +11324,13 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 18.3.1
 
   '@testing-library/dom@9.3.4':
     dependencies:
@@ -10807,7 +11726,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -10844,8 +11763,6 @@ snapshots:
   '@types/methods@1.1.4': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@17.0.45': {}
 
   '@types/node@18.15.3': {}
 
@@ -10917,7 +11834,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.3(jiti@1.21.7))(typescript@5.9.3)':
@@ -11013,12 +11930,38 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@1.6.1(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.20)(vue@3.5.28(typescript@4.9.5))':
+  '@vanilla-extract/css@1.20.1(babel-plugin-macros@3.1.0)':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@vanilla-extract/private': 1.0.9
+      css-what: 6.2.2
+      csstype: 3.2.3
+      dedent: 1.7.1(babel-plugin-macros@3.1.0)
+      deep-object-diff: 1.1.9
+      deepmerge: 4.3.1
+      lru-cache: 10.4.3
+      media-query-parser: 2.0.2
+      modern-ahocorasick: 1.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
+  '@vanilla-extract/dynamic@2.1.5':
+    dependencies:
+      '@vanilla-extract/private': 1.0.9
+
+  '@vanilla-extract/private@1.0.9': {}
+
+  '@vanilla-extract/recipes@0.5.7(@vanilla-extract/css@1.20.1(babel-plugin-macros@3.1.0))':
+    dependencies:
+      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
+
+  '@vercel/analytics@1.6.1(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(svelte@4.2.20)(vue@3.5.28(typescript@5.8.2))':
     optionalDependencies:
       next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       svelte: 4.2.20
-      vue: 3.5.28(typescript@4.9.5)
+      vue: 3.5.28(typescript@5.8.2)
 
   '@vercel/blob@0.13.1':
     dependencies:
@@ -11082,13 +12025,40 @@ snapshots:
       '@vue/shared': 3.5.28
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.28(vue@3.5.28(typescript@4.9.5))':
+  '@vue/server-renderer@3.5.28(vue@3.5.28(typescript@5.8.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.28
       '@vue/shared': 3.5.28
-      vue: 3.5.28(typescript@4.9.5)
+      vue: 3.5.28(typescript@5.8.2)
 
   '@vue/shared@3.5.28': {}
+
+  '@wallet-standard/app@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
+  '@wallet-standard/base@1.1.1': {}
+
+  '@wallet-standard/core@1.1.0':
+    dependencies:
+      '@wallet-standard/app': 1.1.1
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/errors': 0.1.2
+      '@wallet-standard/features': 1.1.1
+      '@wallet-standard/wallet': 1.1.1
+
+  '@wallet-standard/errors@0.1.2':
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+
+  '@wallet-standard/features@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
+  '@wallet-standard/wallet@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -11343,7 +12313,7 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
-  ai@2.2.37(react@18.3.1)(solid-js@1.9.11)(svelte@4.2.20)(vue@3.5.28(typescript@4.9.5)):
+  ai@2.2.37(react@18.3.1)(solid-js@1.9.11)(svelte@4.2.20)(vue@3.5.28(typescript@5.8.2)):
     dependencies:
       eventsource-parser: 1.0.0
       nanoid: 3.3.6
@@ -11351,12 +12321,12 @@ snapshots:
       sswr: 2.0.0(svelte@4.2.20)
       swr: 2.2.0(react@18.3.1)
       swr-store: 0.10.6
-      swrv: 1.0.4(vue@3.5.28(typescript@4.9.5))
+      swrv: 1.0.4(vue@3.5.28(typescript@5.8.2))
     optionalDependencies:
       react: 18.3.1
       solid-js: 1.9.11
       svelte: 4.2.20
-      vue: 3.5.28(typescript@4.9.5)
+      vue: 3.5.28(typescript@5.8.2)
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -11777,6 +12747,8 @@ snapshots:
 
   chalk@5.3.0: {}
 
+  chalk@5.6.2: {}
+
   char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -11821,7 +12793,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -11927,6 +12899,8 @@ snapshots:
 
   commander@11.0.0: {}
 
+  commander@13.1.0: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -12026,21 +13000,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-jest@29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
@@ -12115,6 +13074,8 @@ snapshots:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -12254,6 +13215,8 @@ snapshots:
       which-typed-array: 1.1.20
 
   deep-is@0.1.4: {}
+
+  deep-object-diff@1.1.9: {}
 
   deepmerge@4.3.1: {}
 
@@ -13178,6 +14141,18 @@ snapshots:
       p-cancelable: 3.0.0
       responselike: 3.0.0
 
+  gql.tada@1.11.2(graphql@16.12.0)(typescript@5.8.2):
+    dependencies:
+      '@0no-co/graphql.web': 1.3.2(graphql@16.12.0)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.12.0)(typescript@5.8.2)
+      '@gql.tada/cli-utils': 1.9.2(@0no-co/graphqlsp@1.17.3(graphql@16.12.0)(typescript@5.8.2))(graphql@16.12.0)(typescript@5.8.2)
+      '@gql.tada/internal': 1.2.1(graphql@16.12.0)(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - graphql
+
   graceful-fs@4.2.11: {}
 
   graphql-tag@2.12.6(graphql@16.12.0):
@@ -13688,25 +14663,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
@@ -13725,68 +14681,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 17.0.45
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.19.11
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
@@ -13844,7 +14738,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -13907,7 +14801,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -14016,7 +14910,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -14055,18 +14949,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@17.0.45)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
@@ -14084,6 +14966,8 @@ snapshots:
   jju@1.4.0: {}
 
   jose@4.15.9: {}
+
+  jose@6.2.3: {}
 
   jotai@2.18.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.2.79)(react@18.3.1):
     optionalDependencies:
@@ -14579,6 +15463,10 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-query-parser@2.0.2:
+    dependencies:
+      '@babel/runtime': 7.28.6
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
@@ -14935,6 +15823,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -14942,6 +15832,8 @@ snapshots:
       minimist: 1.2.8
 
   mockdate@3.0.5: {}
+
+  modern-ahocorasick@1.1.0: {}
 
   motion-dom@11.18.1:
     dependencies:
@@ -14982,6 +15874,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@3.3.6: {}
+
+  nanostores@0.10.3: {}
 
   natural-compare@1.4.0: {}
 
@@ -15415,6 +16309,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  poseidon-lite@0.2.1: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-css-variables@0.18.0(postcss@8.4.31):
@@ -15436,13 +16332,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
@@ -15851,6 +16747,17 @@ snapshots:
       '@types/react': 18.2.79
 
   react-remove-scroll@2.5.4(@types/react@18.2.79)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.2.79)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.2.79)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.2.79)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.2.79)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.2.79
+
+  react-remove-scroll@2.7.2(@types/react@18.2.79)(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.8(@types/react@18.2.79)(react@18.3.1)
@@ -16499,7 +17406,7 @@ snapshots:
 
   speedline-core@1.4.3:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 
@@ -16641,7 +17548,7 @@ snapshots:
 
   stripe@14.25.0:
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 22.19.11
       qs: 6.15.0
 
   strtok3@10.3.4:
@@ -16758,9 +17665,9 @@ snapshots:
 
   swrev@4.0.0: {}
 
-  swrv@1.0.4(vue@3.5.28(typescript@4.9.5)):
+  swrv@1.0.4(vue@3.5.28(typescript@5.8.2)):
     dependencies:
-      vue: 3.5.28(typescript@4.9.5)
+      vue: 3.5.28(typescript@5.8.2)
 
   symbol-observable@1.2.0: {}
 
@@ -16774,7 +17681,7 @@ snapshots:
 
   tailwind-merge@2.6.1: {}
 
-  tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
+  tailwindcss@3.3.2(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -16793,7 +17700,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
@@ -17014,27 +17921,6 @@ snapshots:
       typescript: 5.8.2
       webpack: 5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 17.0.45
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.11(@swc/helpers@0.5.18)
-    optional: true
-
   ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -17107,11 +17993,11 @@ snapshots:
       turbo-windows-64: 2.8.10
       turbo-windows-arm64: 2.8.10
 
-  tw-to-css@0.0.12(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5)):
+  tw-to-css@0.0.12(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2)):
     dependencies:
       postcss: 8.4.31
       postcss-css-variables: 0.18.0(postcss@8.4.31)
-      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@17.0.45)(typescript@4.9.5))
+      tailwindcss: 3.3.2(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.8.2))
     transitivePeerDependencies:
       - ts-node
 
@@ -17191,8 +18077,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@4.9.5: {}
 
   typescript@5.8.2: {}
 
@@ -17392,6 +18276,12 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  valibot@0.36.0: {}
+
+  valibot@1.4.1(typescript@5.8.2):
+    optionalDependencies:
+      typescript: 5.8.2
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -17440,15 +18330,15 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vue@3.5.28(typescript@4.9.5):
+  vue@3.5.28(typescript@5.8.2):
     dependencies:
       '@vue/compiler-dom': 3.5.28
       '@vue/compiler-sfc': 3.5.28
       '@vue/runtime-dom': 3.5.28
-      '@vue/server-renderer': 3.5.28(vue@3.5.28(typescript@4.9.5))
+      '@vue/server-renderer': 3.5.28(vue@3.5.28(typescript@5.8.2))
       '@vue/shared': 3.5.28
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.8.2
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
有料メモの決済手段としてStripeに加えてSui（ネイティブSUI）での
決済を追加する。決済はオンチェーンで検証し、購入をDBに記録した上で
購入者にメモを解放するアクセス制御の土台を整備する。

## バックエンド（apps/api / DDD）
- Purchase ドメインモデル・リポジトリ・ユースケースを追加
- IPaymentVerifier ドメインサービスと SuiPaymentVerifier 実装を追加
  - Sui RPC でトランザクションを検証（成立・送金元・送金先・金額）
  - SUI_PAYMENT_VERIFY=false で検証スキップ可能（プレビュー環境向け）
- createPurchase mutation / myPurchasedBookIds / purchasedBookMemo query
- purchases テーブルを Prisma スキーマ（web/api 両方）に追加
- 二重購入・トランザクション再利用を防止し、購入済みは冪等に処理

## フロントエンド（apps/web）
- @mysten/dapp-kit によるウォレット接続 + SUI 送金トランザクション
- SuiCheckoutModal を追加（Stripe と併存）
- 購入後は purchasedBookMemo でメモを解放表示
- Sui 決済の有効化は環境変数で制御（既定 OFF）

## その他
- 新依存（@mysten/sui 等）が TS5+ を要求するため web を TypeScript 5 /
  @types/node 22 へ更新。これに伴う型不整合を bufferToWebp で解消

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VH5PNSNeEfTENzrzxjiJ27