### PR TITLE
fix: db-push workflowで--accept-data-lossが効かない不具合を修正

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -40,7 +40,7 @@ jobs:
             ARGS="$ARGS --accept-data-loss"
           fi
           echo "prisma db push $ARGS"
-          pnpm --filter web db:push -- $ARGS
-          pnpm --filter api db:push -- $ARGS
+          pnpm --filter web exec prisma db push $ARGS
+          pnpm --filter api exec prisma db push $ARGS
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
pnpm db:push -- <args> だとスクリプト(prisma db push)の後ろに
リテラルの -- が残り、prismaが --accept-data-loss を認識できず
データ損失警告で停止していた。ci.ymlと同様にexecでprismaを直接
実行する方式に変更する。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018nDhbVGVTGhWwM6oF3LrLA