### PR TITLE
Refactor BookDetailEditPage to use BookDetailEditModal component

### DIFF
--- a/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
@@ -1,17 +1,6 @@
 import { useState, useEffect } from 'react'
-import dynamic from 'next/dynamic'
 import { Book } from '@/types/book'
-import { ToggleButton } from '@/components/button/ToggleButton'
-import { Loading } from '@/components/icon/Loading'
-import { ImagePicker } from '@/components/button/ImagePicker'
-import { BookSelectBox } from '@/components/input/BookSelectBox'
-import { BookDatePicker } from '@/components/input/BookDatePicker'
-import dayjs from 'dayjs'
-import { useQuery } from '@apollo/client'
-import { BookCreatableSelectBox } from '@/components/input/BookCreatableSelectBox'
-import { Tooltip } from 'react-tooltip'
-import { HintIcon } from '@/components/icon/HintIcon'
-import { MaskingHint } from '@/components/label/MaskingHint'
+import { BookDetailEditModal } from './BookDetailEditModal'
 import { useReward } from 'react-rewards'
 import {
   getBookDraft,
@@ -19,24 +8,6 @@ import {
   removeBookDraft,
   cleanupOldDrafts,
 } from '@/utils/localStorage'
-import { SheetSelectBox } from '@/components/input/SheetSelectBox'
-import { getBookCategoriesQuery } from '@/features/books/api'
-
-// SSRを無効にしてクライアントサイドのみでロード
-const MarkdownEditor = dynamic(
-  () =>
-    import('@/components/input/MarkdownEditor').then(
-      (mod) => mod.MarkdownEditor
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex min-h-[300px] items-center justify-center rounded-lg border border-gray-200 bg-gray-50">
-        <span className="text-gray-400">エディタを読み込み中...</span>
-      </div>
-    ),
-  }
-)
 
 interface Props {
   book: Book
@@ -110,17 +81,6 @@ export const BookDetailEditPage: React.FC<Props> = ({
     book.isPublicMemo,
   ])
 
-  // カテゴリ一覧（GraphQL）
-  const { data: categoriesData } = useQuery<{ bookCategories: string[] }>(
-    getBookCategoriesQuery
-  )
-  const options = categoriesData
-    ? categoriesData.bookCategories.map((category) => ({
-        value: category,
-        label: category,
-      }))
-    : []
-
   const handleSave = async () => {
     setLoading(true)
     try {
@@ -177,192 +137,31 @@ export const BookDetailEditPage: React.FC<Props> = ({
   }
 
   return (
-    <div className="flex h-full min-w-full flex-col justify-between rounded-md">
-      <div className="flex-1">
-        {hasDraft && (
-          <div className="mx-4 mt-4 rounded-md bg-blue-50 p-3 text-sm text-blue-800">
-            💾 下書きが復元されました
-          </div>
-        )}
-        <div className="flex justify-end p-4">
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={onCancel}
-              className="rounded-md bg-gray-500 px-4 py-2 text-white hover:bg-gray-600 disabled:opacity-50"
-              disabled={loading}
-            >
-              キャンセル
-            </button>
-            <button
-              onClick={handleSave}
-              className="relative rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 disabled:opacity-50"
-              disabled={loading}
-            >
-              {loading ? (
-                <Loading className="h-5 w-5 border-2 border-white" />
-              ) : (
-                '保存'
-              )}
-              <span
-                id="saveRewardId"
-                className="absolute left-1/2 top-0 -translate-x-1/2 transform"
-              ></span>
-            </button>
-          </div>
+    <div className="mx-auto max-w-xl rounded-md bg-white">
+      {hasDraft && (
+        <div className="mx-4 mt-4 rounded-md bg-blue-50 p-3 text-sm text-blue-800">
+          💾 下書きが復元されました
         </div>
-
-        <div className="px-4">
-          <div className="mx-auto mb-4 w-[200px]">
-            <ImagePicker
-              img={book.image}
-              onImageLoad={(image) => setBook({ ...book, image })}
-            />
-          </div>
-
-          <div className="mb-6 text-center">
-            <h1 className="mb-2">
-              <input
-                type="text"
-                value={book?.title || ''}
-                onChange={(e) => setBook({ ...book, title: e.target.value })}
-                placeholder="タイトルを入力"
-                className="w-full rounded border-none bg-transparent px-3 py-2 text-center text-2xl font-bold transition-colors hover:bg-gray-50 focus:border focus:border-blue-300 focus:bg-white focus:outline-none"
-                tabIndex={1}
-              />
-            </h1>
-
-            <p className="mb-4">
-              <input
-                type="text"
-                value={book?.author || ''}
-                onChange={(e) => setBook({ ...book, author: e.target.value })}
-                placeholder="著者を入力"
-                className="w-full rounded border-none bg-transparent px-3 py-2 text-center text-gray-600 transition-colors hover:bg-gray-50 focus:border focus:border-blue-300 focus:bg-white focus:outline-none"
-                tabIndex={2}
-              />
-            </p>
-
-            <div className="flex justify-center space-x-8 text-sm">
-              <div className="text-center">
-                <label className="mb-1 block text-xs font-semibold text-gray-500">
-                  カテゴリ
-                </label>
-                <BookCreatableSelectBox
-                  label=""
-                  value={
-                    book?.category
-                      ? { value: book.category, label: book.category }
-                      : null
-                  }
-                  options={options}
-                  onChange={(category) =>
-                    setBook({
-                      ...book,
-                      category:
-                        typeof category === 'string'
-                          ? category
-                          : (category as { value: string } | null)?.value || '',
-                    })
-                  }
-                  tabIndex={3}
-                />
-              </div>
-              <div className="text-center">
-                <label className="mb-1 block text-xs font-semibold text-gray-500">
-                  評価
-                </label>
-                <BookSelectBox
-                  label=""
-                  value={book?.impression}
-                  onChange={(e) =>
-                    setBook({ ...book, impression: e.target.value })
-                  }
-                  tabIndex={4}
-                />
-              </div>
-              <div className="text-center">
-                <label className="mb-1 block text-xs font-semibold text-gray-500">
-                  読了日
-                </label>
-                <BookDatePicker
-                  label=""
-                  value={
-                    book?.finished
-                      ? dayjs(book.finished).format('YYYY-MM-DD')
-                      : ''
-                  }
-                  onChange={(e) =>
-                    setBook({ ...book, finished: e.target.value })
-                  }
-                  tabIndex={5}
-                />
-              </div>
-              <div className="text-center">
-                <label className="mb-1 block text-xs font-semibold text-gray-500">
-                  シート
-                </label>
-                <SheetSelectBox
-                  value={book?.sheetId}
-                  onChange={(sheet) => {
-                    setBook({
-                      ...book,
-                      sheetId: sheet.id,
-                      sheet: sheet.name,
-                    })
-                  }}
-                  label=""
-                  tabIndex={6}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="px-4">
-          <div className="mb-4">
-            <div className="mb-2 flex items-center justify-between">
-              <div className="flex items-center">
-                <h2 className="text-lg font-semibold text-gray-800">メモ</h2>
-                <div className="ml-2">
-                  <MaskingHint />
-                </div>
-              </div>
-              <div className="flex items-center space-x-2">
-                <ToggleButton
-                  label="公開する"
-                  checked={book?.isPublicMemo || false}
-                  onChange={() =>
-                    setBook({
-                      ...book,
-                      isPublicMemo: !(book.isPublicMemo || false),
-                    })
-                  }
-                />
-                <HintIcon className="ml-2" data-tooltip-id="public-memo-hint" />
-                <Tooltip id="public-memo-hint" className="!w-[300px]">
-                  メモを公開すると、他のユーザーがあなたの感想やメモを閲覧できるようになります。非公開の場合は、あなただけが閲覧できます。
-                </Tooltip>
-              </div>
-            </div>
-
-            <MarkdownEditor
-              value={book?.memo || ''}
-              onChange={(memo) => setBook({ ...book, memo })}
-              minHeight="300px"
-            />
-          </div>
-        </div>
-
-        <div className="mx-4 mt-8 border-t border-gray-200 pb-4 pt-4 text-center">
-          <button
-            onClick={handleDelete}
-            className="text-xs text-gray-400 hover:text-red-500 disabled:opacity-50"
-            disabled={loading}
-          >
-            この書籍を削除する
-          </button>
-        </div>
+      )}
+      <div className="flex justify-end px-4 pt-4">
+        <button
+          onClick={onCancel}
+          className="rounded-md bg-gray-500 px-4 py-2 text-white hover:bg-gray-600 disabled:opacity-50"
+          disabled={loading}
+        >
+          キャンセル
+        </button>
       </div>
+      {/* 横スライド（サイドバー）と同じ編集フォームを再利用してレイアウトを統一する */}
+      <BookDetailEditModal
+        currentBook={initialBook}
+        book={book}
+        onClick={handleSave}
+        setBook={(editBook: Book) => setBook({ ...editBook })}
+        loading={loading}
+        onDelete={handleDelete}
+      />
+      <span id="saveRewardId" className="flex justify-center"></span>
     </div>
   )
 }

--- a/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
@@ -137,7 +137,7 @@ export const BookDetailEditPage: React.FC<Props> = ({
   }
 
   return (
-    <div className="mx-auto max-w-xl rounded-md bg-white">
+    <div className="mx-auto max-w-3xl rounded-md bg-white">
       {hasDraft && (
         <div className="mx-4 mt-4 rounded-md bg-blue-50 p-3 text-sm text-blue-800">
           💾 下書きが復元されました


### PR DESCRIPTION
## 概要

`BookDetailEditPage` コンポーネントを大幅にリファクタリングし、編集フォームのUIロジックを新しい `BookDetailEditModal` コンポーネントに抽出しました。これにより、コンポーネント間でのコード再利用性が向上し、保守性が改善されます。

## 変更の種類

- [x] Refactoring

## 詳細

### 削除された内容
- `BookDetailEditPage` から以下のインポートと関連ロジックを削除：
  - `ToggleButton`, `Loading`, `ImagePicker`, `BookSelectBox`, `BookDatePicker` などのUI コンポーネント
  - `MarkdownEditor` の動的インポート（SSR無効化）
  - GraphQL クエリ `getBookCategoriesQuery` とカテゴリ取得ロジック
  - メモ編集、カテゴリ選択、評価選択、読了日選択、シート選択などの詳細なフォームUI

### 追加された内容
- `BookDetailEditModal` コンポーネントのインポート
- `BookDetailEditModal` を使用した統一されたフォームレイアウト
- より簡潔なページ構造（下書き復元通知、キャンセルボタン、モーダルコンポーネント）

### 効果
- **コード削減**: 約160行のUIロジックを `BookDetailEditModal` に集約
- **再利用性向上**: 同じ編集フォームをサイドバーとページの両方で使用可能
- **保守性向上**: フォームUIの変更が一箇所で済む
- **責任分離**: ページコンポーネントは状態管理と保存ロジックに専念

## チェックリスト

- [ ] `pnpm validate` が通ること
- [ ] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01X71ph9VjykQKCj5MboCcC3