### PR TITLE
Allow specifying branch for DB Push workflow

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -3,6 +3,11 @@ name: DB Push
 on:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'スキーマを取得するブランチ（空欄ならワークフロー実行時に選択したブランチ）'
+        required: false
+        default: ''
+        type: string
       accept_data_loss:
         description: 'データ損失を許容して push する（--accept-data-loss）'
         required: false
@@ -21,6 +26,9 @@ jobs:
     environment: Production
     steps:
       - uses: actions/checkout@v4
+        with:
+          # branch が指定されていればそのブランチを、空欄なら実行時に選択したブランチを使う
+          ref: ${{ inputs.branch || github.ref }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 概要

DB Push ワークフロー（`db-push.yml`）に、スキーマを取得するブランチを指定できる入力パラメータを追加しました。

ブランチを明示的に指定しない場合は、ワークフロー実行時に選択したブランチが使用されます。これにより、異なるブランチのスキーマを本番環境にプッシュする際の柔軟性が向上します。

### 変更内容

- `workflow_dispatch` の `inputs` に `branch` パラメータを追加
  - 説明: スキーマを取得するブランチ（空欄ならワークフロー実行時に選択したブランチ）
  - 型: string
  - 必須: false
  - デフォルト: 空文字列

- `actions/checkout@v4` ステップに `ref` パラメータを設定
  - `${{ inputs.branch || github.ref }}` で、指定されたブランチまたは実行時選択ブランチを使用

## 変更の種類

- [x] Refactoring
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other

## チェックリスト

- [x] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

**注**: ワークフロー設定の変更のため、テストは不要です。CI で自動検証されます。

https://claude.ai/code/session_018Ugw1RyBbuHfKiMdMnbTza