### PR TITLE
fix: 裏口ログインのメールアドレス入力をブラウザに保存されるようにする

### DIFF
--- a/apps/web/src/components/layout/LoginModal.tsx
+++ b/apps/web/src/components/layout/LoginModal.tsx
@@ -64,6 +64,8 @@ export const LoginModal: React.FC = () => {
             <form onSubmit={handleBackdoorLogin} className="space-y-3">
               <input
                 type="email"
+                name="email"
+                autoComplete="email"
                 placeholder="メールアドレス"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}


### PR DESCRIPTION
input要素に name="email" と autoComplete="email" を追加。
ブラウザはname属性を持つ入力欄の値を記憶してオートフィル候補にするため、
これらが欠けていると値が保存されなかった。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019qvBMc4PTdLA5NBbUdSku4