### PR TITLE
feat: プレビュー環境用のAPIデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy-api-preview.yml
+++ b/.github/workflows/deploy-api-preview.yml
@@ -1,0 +1,140 @@
+name: Deploy API to Cloud Run (Preview)
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'apps/api/**'
+      - 'docker/Dockerfile.api'
+      - '.github/workflows/deploy-api-preview.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'デプロイ環境'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+        - preview
+
+# 同じプレビューサービスへ複数の PR が同時にデプロイして競合しないよう直列化する
+concurrency:
+  group: deploy-api-preview
+  cancel-in-progress: false
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  SERVICE_NAME: kidoku-api-preview
+  REGION: asia-northeast1
+  IMAGE: gcr.io/${{ secrets.GCP_PROJECT_ID }}/kidoku-api-preview
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Preview 用の GitHub Environment（Secrets はこちらに登録する）
+    environment: Preview
+
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Configure Docker for GCR
+        run: |
+          gcloud auth configure-docker
+
+      - name: Build and push Docker image
+        run: |
+          docker build -f docker/Dockerfile.api -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        id: deploy
+        run: |
+          gcloud run deploy ${{ env.SERVICE_NAME }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --port 4000 \
+            --memory 256Mi \
+            --cpu 1 \
+            --min-instances 0 \
+            --max-instances 2 \
+            --timeout 30 \
+            --set-env-vars "NODE_ENV=production" \
+            --set-env-vars "FRONTEND_URL=${{ secrets.FRONTEND_URL }}" \
+            --set-env-vars "DATABASE_URL=${{ secrets.DATABASE_URL }}" \
+            --set-env-vars "NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}" \
+            --set-env-vars "MEILI_HOST=${{ secrets.MEILI_HOST }}" \
+            --set-env-vars "MEILI_MASTER_KEY=${{ secrets.MEILI_MASTER_KEY }}" \
+            --set-env-vars "ADMIN_API_KEY=${{ secrets.ADMIN_API_KEY }}" \
+            --set-env-vars "RAKUTEN_APPLICATION_ID=${{ secrets.RAKUTEN_APPLICATION_ID }}" \
+            --set-env-vars "RAKUTEN_ACCESS_KEY=${{ secrets.RAKUTEN_ACCESS_KEY }}"
+          URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} --region ${{ env.REGION }} --format 'value(status.url)')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Service deployed to: $URL"
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- preview-api-deploy -->';
+            const url = process.env.PREVIEW_URL;
+            const body = [
+              marker,
+              '🚀 **プレビュー API サーバーをデプロイしました**',
+              '',
+              `- GraphQL エンドポイント: ${url}/graphql`,
+              `- コミット: \`${context.sha}\``,
+              '',
+              '> このプレビュー API は共有の `kidoku-api-preview` サービスです。',
+              '> 別 PR がデプロイすると最新のデプロイで上書きされます。',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number },
+            );
+            const existing = comments.find(
+              (c) => c.user.type === 'Bot' && c.body && c.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,19 @@ pnpm --filter web lighthouse
 - `apps/api`配下の変更でAPIデプロイトリガー
 - 環境変数はGitHub Secretsで管理
 
+#### APIデプロイワークフロー
+
+| ワークフロー | トリガー | デプロイ先 | GitHub Environment |
+|---|---|---|---|
+| `.github/workflows/deploy-api.yml` | main/master への push（`apps/api/**` 変更時） | Cloud Run サービス `kidoku-api`（本番） | `Production` |
+| `.github/workflows/deploy-api-preview.yml` | PR（main/master 宛て、`apps/api/**` 変更時） | Cloud Run サービス `kidoku-api-preview`（プレビュー） | `Preview` |
+
+- プレビュー用APIは全PR共通の単一サービス `kidoku-api-preview` にデプロイされ、最新のデプロイで上書きされる
+- プレビューデプロイ完了後、PRに GraphQL エンドポイントURLがコメントされる
+- プレビュー用の Secrets（`DATABASE_URL`, `NEXTAUTH_SECRET`, `FRONTEND_URL` 等）は GitHub の `Preview` Environment に登録する
+- プレビューDBへのスキーマ反映は `db-push.yml` を `Preview` 環境指定で手動実行する
+- フォークからのPRはSecretsにアクセスできないため、プレビューデプロイは同一リポジトリ内のブランチPRでのみ動作する
+
 ## サンドボックス環境での開発
 
 詳細は [docs/SANDBOX_SETUP.md](./docs/SANDBOX_SETUP.md) を参照。

--- a/apps/api/DEPLOYMENT.md
+++ b/apps/api/DEPLOYMENT.md
@@ -42,17 +42,20 @@ gcloud iam service-accounts keys create key.json \
 
 ### 2. GitHub Secretsの設定
 
-以下のシークレットをGitHubリポジトリに設定:
+以下のシークレットをGitHubリポジトリ（本番は `Production`、プレビューは `Preview` Environment）に設定:
 
 - `GCP_PROJECT_ID`: Google CloudプロジェクトID
 - `GCP_SA_KEY`: サービスアカウントキー（key.jsonの内容）
-- `FRONTEND_URL`: フロントエンドのURL（例: https://kidoku.example.com）
-- `DB_HOST`: TiDBクラウドのホスト
-- `DB_PORT`: データベースポート
-- `DB_USER`: データベースユーザー
-- `DB_PASS`: データベースパスワード
-- `DB_NAME`: データベース名
-- `NEXTAUTH_SECRET`: NextAuth.jsのシークレット
+- `FRONTEND_URL`: フロントエンドのURL（CORS許可オリジン。カンマ区切りで複数指定可。例: https://kidoku.example.com）
+- `DATABASE_URL`: データベース接続文字列（例: `mysql://user:pass@host:3306/kidoku`）
+- `NEXTAUTH_SECRET`: NextAuth.jsのシークレット（フロントエンドと一致させること）
+- `MEILI_HOST`: MeiliSearchのホストURL
+- `MEILI_MASTER_KEY`: MeiliSearchのマスターキー
+- `ADMIN_API_KEY`: 管理用APIキー
+- `RAKUTEN_APPLICATION_ID`: 楽天ブックスAPIのアプリケーションID
+- `RAKUTEN_ACCESS_KEY`: 楽天ブックスAPIのアクセスキー
+
+> **Note**: APIが参照する環境変数はソースコード上 `DATABASE_URL`（Prisma接続）に統一されている。`DB_HOST` などの個別変数は使用しない。
 
 ## ローカルでのテスト
 
@@ -69,11 +72,7 @@ docker build -f docker/Dockerfile.api -t kidoku-api:local .
 docker run -p 4000:4000 \
   -e NODE_ENV=production \
   -e FRONTEND_URL=http://localhost:3000 \
-  -e DB_HOST=localhost \
-  -e DB_PORT=3306 \
-  -e DB_USER=root \
-  -e DB_PASS=password \
-  -e DB_NAME=kidoku \
+  -e DATABASE_URL="mysql://root:password@localhost:3306/kidoku" \
   -e NEXTAUTH_SECRET=your-secret \
   kidoku-api:local
 
@@ -85,7 +84,15 @@ curl http://localhost:4000/health
 
 ### 自動デプロイ（推奨）
 
-main/masterブランチに`apps/api/`配下の変更をプッシュすると、GitHub Actionsが自動的にデプロイします。
+| ワークフロー | トリガー | デプロイ先 | GitHub Environment |
+|---|---|---|---|
+| `.github/workflows/deploy-api.yml` | main/master への push（`apps/api/**` 変更時） | `kidoku-api`（本番） | `Production` |
+| `.github/workflows/deploy-api-preview.yml` | PR（main/master 宛て、`apps/api/**` 変更時） | `kidoku-api-preview`（プレビュー） | `Preview` |
+
+- 本番: main/masterブランチに`apps/api/`配下の変更をプッシュすると自動デプロイ
+- プレビュー: PR作成・更新時に全PR共通の単一サービス `kidoku-api-preview` へ自動デプロイ（最新のデプロイで上書き）。デプロイ後にPRへGraphQLエンドポイントURLがコメントされる
+
+> **Note**: `gcloud run deploy` はサービスが存在しなければ自動作成するため、プレビュー用サービスの事前作成は不要。初回ワークフロー実行時に `kidoku-api-preview` が作られる。フォークからのPRはSecretsにアクセスできないため、プレビューデプロイは同一リポジトリ内ブランチのPRでのみ動作する。
 
 ### 手動デプロイ
 
@@ -110,7 +117,15 @@ gcloud run deploy kidoku-api \
   --min-instances 0 \
   --max-instances 10 \
   --timeout 60 \
-  --set-env-vars "NODE_ENV=production,FRONTEND_URL=https://kidoku.example.com"
+  --set-env-vars "NODE_ENV=production" \
+  --set-env-vars "FRONTEND_URL=https://kidoku.example.com" \
+  --set-env-vars "DATABASE_URL=mysql://user:pass@host:3306/kidoku" \
+  --set-env-vars "NEXTAUTH_SECRET=your-secret" \
+  --set-env-vars "MEILI_HOST=https://meili.example.com" \
+  --set-env-vars "MEILI_MASTER_KEY=your-master-key" \
+  --set-env-vars "ADMIN_API_KEY=your-admin-api-key" \
+  --set-env-vars "RAKUTEN_APPLICATION_ID=your-app-id" \
+  --set-env-vars "RAKUTEN_ACCESS_KEY=your-access-key"
 ```
 
 ## 本番環境の確認


### PR DESCRIPTION
PR作成時に apps/api 配下の変更を検知し、Cloud Run の
kidoku-api-preview サービス（Preview環境のSecrets使用）へ
自動デプロイするワークフローを追加。デプロイ後にPRへ
GraphQLエンドポイントURLをコメントする。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DY1zEqMXELVcKL9PUAPTxc