### PR TITLE
feat: ログインしていないユーザーでもいいねできるようにする

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -149,14 +149,16 @@ model Follow {
 }
 
 model Like {
-  id      Int      @id @default(autoincrement()) @db.UnsignedInt
-  userId  String   @map("user_id")
-  bookId  Int      @map("book_id")
-  created DateTime @default(now()) @db.DateTime(0)
-  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  book    books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  id          Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId      String?  @map("user_id")
+  anonymousId String?  @map("anonymous_id") @db.VarChar(64)
+  bookId      Int      @map("book_id")
+  created     DateTime @default(now()) @db.DateTime(0)
+  user        User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book        books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
 
   @@unique([userId, bookId], map: "uniq_user_book")
+  @@unique([anonymousId, bookId], map: "uniq_anon_book")
   @@index([bookId])
   @@map("likes")
 }
@@ -180,15 +182,16 @@ model Purchase {
 }
 
 model Notification {
-  id      Int      @id @default(autoincrement()) @db.UnsignedInt
-  userId  String   @map("user_id")
-  actorId String   @map("actor_id")
-  type    String   @db.VarChar(20)
-  bookId  Int?     @map("book_id")
-  read    Boolean  @default(false)
-  created DateTime @default(now()) @db.DateTime(0)
-  user    User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
-  actor   User     @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
+  id               Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId           String   @map("user_id")
+  actorId          String?  @map("actor_id")
+  actorAnonymousId String?  @map("actor_anonymous_id") @db.VarChar(64)
+  type             String   @db.VarChar(20)
+  bookId           Int?     @map("book_id")
+  read             Boolean  @default(false)
+  created          DateTime @default(now()) @db.DateTime(0)
+  user             User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
+  actor            User?    @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
 
   @@unique([userId, actorId, type, bookId], map: "uniq_user_actor_type_book")
   @@index([userId])

--- a/apps/api/src/application/usecases/likes/get-my-liked-book-ids.ts
+++ b/apps/api/src/application/usecases/likes/get-my-liked-book-ids.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { ILikeRepository } from '../../../domain/repositories/like';
+import { ILikeRepository, LikeActor } from '../../../domain/repositories/like';
 
 @Injectable()
 export class GetMyLikedBookIdsUseCase {
   constructor(private readonly likeRepository: ILikeRepository) {}
 
-  async execute(userId: string): Promise<number[]> {
-    return this.likeRepository.getLikedBookIds(userId);
+  async execute(actor: LikeActor): Promise<number[]> {
+    return this.likeRepository.getLikedBookIds(actor);
   }
 }

--- a/apps/api/src/application/usecases/likes/like-book.spec.ts
+++ b/apps/api/src/application/usecases/likes/like-book.spec.ts
@@ -31,12 +31,35 @@ describe('LikeBookUseCase', () => {
     });
     mockLikeRepo.countByBook.mockResolvedValue(3);
 
-    const count = await useCase.execute('liker', 1);
+    const count = await useCase.execute({ kind: 'user', userId: 'liker' }, 1);
 
     expect(count).toBe(3);
     expect(mockNotificationRepo.create).toHaveBeenCalledWith({
       userId: 'owner',
       actorId: 'liker',
+      actorAnonymousId: null,
+      type: 'like',
+      bookId: 1,
+    });
+  });
+
+  it('匿名ユーザーのいいねで匿名として通知が作成される', async () => {
+    mockLikeRepo.like.mockResolvedValue({
+      created: true,
+      bookOwnerId: 'owner',
+    });
+    mockLikeRepo.countByBook.mockResolvedValue(5);
+
+    const count = await useCase.execute(
+      { kind: 'anonymous', anonymousId: 'anon-123' },
+      1,
+    );
+
+    expect(count).toBe(5);
+    expect(mockNotificationRepo.create).toHaveBeenCalledWith({
+      userId: 'owner',
+      actorId: null,
+      actorAnonymousId: 'anon-123',
       type: 'like',
       bookId: 1,
     });
@@ -49,7 +72,7 @@ describe('LikeBookUseCase', () => {
     });
     mockLikeRepo.countByBook.mockResolvedValue(3);
 
-    await useCase.execute('liker', 1);
+    await useCase.execute({ kind: 'user', userId: 'liker' }, 1);
 
     expect(mockNotificationRepo.create).not.toHaveBeenCalled();
   });

--- a/apps/api/src/application/usecases/likes/like-book.ts
+++ b/apps/api/src/application/usecases/likes/like-book.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ILikeRepository } from '../../../domain/repositories/like';
+import { ILikeRepository, LikeActor } from '../../../domain/repositories/like';
 import { INotificationRepository } from '../../../domain/repositories/notification';
 
 @Injectable()
@@ -9,15 +9,16 @@ export class LikeBookUseCase {
     private readonly notificationRepository: INotificationRepository,
   ) {}
 
-  async execute(userId: string, bookId: number): Promise<number> {
+  async execute(actor: LikeActor, bookId: number): Promise<number> {
     const { created, bookOwnerId } = await this.likeRepository.like(
-      userId,
+      actor,
       bookId,
     );
     if (created && bookOwnerId) {
       await this.notificationRepository.create({
         userId: bookOwnerId,
-        actorId: userId,
+        actorId: actor.kind === 'user' ? actor.userId : null,
+        actorAnonymousId: actor.kind === 'anonymous' ? actor.anonymousId : null,
         type: 'like',
         bookId,
       });

--- a/apps/api/src/application/usecases/likes/unlike-book.ts
+++ b/apps/api/src/application/usecases/likes/unlike-book.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { ILikeRepository } from '../../../domain/repositories/like';
+import { ILikeRepository, LikeActor } from '../../../domain/repositories/like';
 
 @Injectable()
 export class UnlikeBookUseCase {
   constructor(private readonly likeRepository: ILikeRepository) {}
 
-  async execute(userId: string, bookId: number): Promise<number> {
-    await this.likeRepository.unlike(userId, bookId);
+  async execute(actor: LikeActor, bookId: number): Promise<number> {
+    await this.likeRepository.unlike(actor, bookId);
     return this.likeRepository.countByBook(bookId);
   }
 }

--- a/apps/api/src/domain/repositories/like.ts
+++ b/apps/api/src/domain/repositories/like.ts
@@ -1,10 +1,18 @@
+/**
+ * いいねの操作主体。
+ * ログインユーザーは userId、未ログイン（匿名）ユーザーは Cookie 由来の anonymousId で識別する。
+ */
+export type LikeActor =
+  | { kind: 'user'; userId: string }
+  | { kind: 'anonymous'; anonymousId: string };
+
 export abstract class ILikeRepository {
   /** いいねする。新規作成かどうかと本の所有者IDを返す */
   abstract like(
-    userId: string,
+    actor: LikeActor,
     bookId: number,
   ): Promise<{ created: boolean; bookOwnerId: string | null }>;
-  abstract unlike(userId: string, bookId: number): Promise<void>;
-  abstract getLikedBookIds(userId: string): Promise<number[]>;
+  abstract unlike(actor: LikeActor, bookId: number): Promise<void>;
+  abstract getLikedBookIds(actor: LikeActor): Promise<number[]>;
   abstract countByBook(bookId: number): Promise<number>;
 }

--- a/apps/api/src/domain/repositories/notification.ts
+++ b/apps/api/src/domain/repositories/notification.ts
@@ -3,7 +3,10 @@ import { NotificationItem } from '../types/social';
 
 export interface CreateNotificationParams {
   userId: string;
-  actorId: string;
+  /** ログインユーザーの操作者ID。匿名操作の場合は null */
+  actorId?: string | null;
+  /** 匿名（未ログイン）操作者の識別子。ログインユーザーの場合は null */
+  actorAnonymousId?: string | null;
   type: 'follow' | 'like';
   bookId?: number | null;
 }

--- a/apps/api/src/infrastructure/auth/optional-gql-auth.guard.ts
+++ b/apps/api/src/infrastructure/auth/optional-gql-auth.guard.ts
@@ -1,0 +1,21 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+/**
+ * 任意認証用の GraphQL ガード。
+ * X-User-Id ヘッダーがあれば認証してユーザー情報を request に載せるが、
+ * 無い／不正でも例外を投げず未認証（user = undefined）として処理を継続する。
+ * ログイン不要で利用できるエンドポイント（匿名いいね等）で使用する。
+ */
+@Injectable()
+export class OptionalGqlAuthGuard extends AuthGuard('header') {
+  getRequest(ctx: ExecutionContext) {
+    return GqlExecutionContext.create(ctx).getContext().req;
+  }
+
+  // 認証失敗時も例外を投げず、未認証として通す
+  handleRequest(err: any, user: any) {
+    return user || undefined;
+  }
+}

--- a/apps/api/src/infrastructure/repositories/like.ts
+++ b/apps/api/src/infrastructure/repositories/like.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../database/prisma.service';
-import { ILikeRepository } from '../../domain/repositories/like';
+import { ILikeRepository, LikeActor } from '../../domain/repositories/like';
 
 @Injectable()
 export class LikeRepository implements ILikeRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async like(
-    userId: string,
+    actor: LikeActor,
     bookId: number,
   ): Promise<{ created: boolean; bookOwnerId: string | null }> {
     const book = await this.prisma.books.findUnique({
@@ -16,27 +16,37 @@ export class LikeRepository implements ILikeRepository {
     });
     if (!book) return { created: false, bookOwnerId: null };
 
-    // 自分の本にはいいねできない
-    if (book.userId === userId) {
+    // 自分の本にはいいねできない（所有者を判定できるログインユーザーのみ対象）
+    if (actor.kind === 'user' && book.userId === actor.userId) {
       return { created: false, bookOwnerId: book.userId };
     }
 
     const existing = await this.prisma.like.findUnique({
-      where: { userId_bookId: { userId, bookId } },
+      where: this.uniqueWhere(actor, bookId),
     });
     if (existing) return { created: false, bookOwnerId: book.userId };
 
-    await this.prisma.like.create({ data: { userId, bookId } });
+    await this.prisma.like.create({
+      data:
+        actor.kind === 'user'
+          ? { userId: actor.userId, bookId }
+          : { anonymousId: actor.anonymousId, bookId },
+    });
     return { created: true, bookOwnerId: book.userId };
   }
 
-  async unlike(userId: string, bookId: number): Promise<void> {
-    await this.prisma.like.deleteMany({ where: { userId, bookId } });
+  async unlike(actor: LikeActor, bookId: number): Promise<void> {
+    await this.prisma.like.deleteMany({
+      where: this.actorWhere(actor, bookId),
+    });
   }
 
-  async getLikedBookIds(userId: string): Promise<number[]> {
+  async getLikedBookIds(actor: LikeActor): Promise<number[]> {
     const likes = await this.prisma.like.findMany({
-      where: { userId },
+      where:
+        actor.kind === 'user'
+          ? { userId: actor.userId }
+          : { anonymousId: actor.anonymousId },
       select: { bookId: true },
     });
     return likes.map((l) => l.bookId);
@@ -44,5 +54,19 @@ export class LikeRepository implements ILikeRepository {
 
   async countByBook(bookId: number): Promise<number> {
     return this.prisma.like.count({ where: { bookId } });
+  }
+
+  /** findUnique 用の複合ユニークキー */
+  private uniqueWhere(actor: LikeActor, bookId: number) {
+    return actor.kind === 'user'
+      ? { userId_bookId: { userId: actor.userId, bookId } }
+      : { anonymousId_bookId: { anonymousId: actor.anonymousId, bookId } };
+  }
+
+  /** deleteMany 用の通常 where */
+  private actorWhere(actor: LikeActor, bookId: number) {
+    return actor.kind === 'user'
+      ? { userId: actor.userId, bookId }
+      : { anonymousId: actor.anonymousId, bookId };
   }
 }

--- a/apps/api/src/infrastructure/repositories/notification.ts
+++ b/apps/api/src/infrastructure/repositories/notification.ts
@@ -12,10 +12,43 @@ export class NotificationRepository implements INotificationRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(params: CreateNotificationParams): Promise<void> {
-    // 自分自身の操作では通知しない
-    if (params.userId === params.actorId) return;
+    // 自分自身の操作では通知しない（ログインユーザーのみ該当）
+    if (params.actorId && params.userId === params.actorId) return;
 
-    const { userId, actorId, type } = params;
+    const { userId, actorId = null, actorAnonymousId = null, type } = params;
+
+    // 匿名操作者の通知。
+    // (受信者・匿名操作者・種別・本) で集約するが、ユニーク制約は actorId(NULL) を
+    // 含むため MySQL では NULL 同士が別物扱いとなり upsert で集約できない。
+    // そのため明示的に検索→更新／作成して重複作成を防ぐ。
+    if (actorAnonymousId) {
+      if (params.bookId != null) {
+        const existing = await this.prisma.notification.findFirst({
+          where: { userId, actorAnonymousId, type, bookId: params.bookId },
+          select: { id: true },
+        });
+        if (existing) {
+          await this.prisma.notification.update({
+            where: { id: existing.id },
+            data: { read: false, created: new Date() },
+          });
+          return;
+        }
+      }
+      await this.prisma.notification.create({
+        data: {
+          userId,
+          actorId: null,
+          actorAnonymousId,
+          type,
+          bookId: params.bookId ?? null,
+        },
+      });
+      return;
+    }
+
+    // 操作者を特定できない通知は作成しない
+    if (!actorId) return;
 
     // 本に紐づく通知（いいね等）は (受信者・操作者・種別・本) ごとに1件に集約する。
     // いいね→いいね解除→再いいねを繰り返しても通知が重複作成されないようにし、
@@ -84,8 +117,9 @@ export class NotificationRepository implements INotificationRepository {
       bookId: n.bookId,
       read: n.read,
       created: n.created,
-      actorName: n.actor.name || '',
-      actorImage: n.actor.image || null,
+      // actor が null の通知は未ログインユーザーによる操作（匿名）
+      actorName: n.actor?.name || '匿名ユーザー',
+      actorImage: n.actor?.image || null,
       bookTitle: n.bookId ? (titleMap.get(n.bookId) ?? null) : null,
     }));
 

--- a/apps/api/src/presentation/dto/like.ts
+++ b/apps/api/src/presentation/dto/like.ts
@@ -4,4 +4,8 @@ import { Field, InputType, Int } from '@nestjs/graphql';
 export class LikeBookInput {
   @Field(() => Int)
   bookId: number;
+
+  /** 未ログインユーザーの識別子（Cookie由来）。ログイン時は不要 */
+  @Field(() => String, { nullable: true })
+  anonymousId?: string;
 }

--- a/apps/api/src/presentation/resolvers/like.ts
+++ b/apps/api/src/presentation/resolvers/like.ts
@@ -1,7 +1,8 @@
-import { UseGuards } from '@nestjs/common';
+import { BadRequestException, UseGuards } from '@nestjs/common';
 import { Query, Mutation, Resolver, Args, Int } from '@nestjs/graphql';
-import { GqlAuthGuard } from '../../infrastructure/auth/gql-auth.guard';
+import { OptionalGqlAuthGuard } from '../../infrastructure/auth/optional-gql-auth.guard';
 import { CurrentUser } from '../../infrastructure/auth/current-user.decorator';
+import { LikeActor } from '../../domain/repositories/like';
 import { LikeBookUseCase } from '../../application/usecases/likes/like-book';
 import { UnlikeBookUseCase } from '../../application/usecases/likes/unlike-book';
 import { GetMyLikedBookIdsUseCase } from '../../application/usecases/likes/get-my-liked-book-ids';
@@ -16,26 +17,56 @@ export class LikeResolver {
   ) {}
 
   @Mutation(() => Int)
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(OptionalGqlAuthGuard)
   async likeBook(
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string } | undefined,
     @Args('input') input: LikeBookInput,
   ): Promise<number> {
-    return this.likeBookUseCase.execute(user.id, input.bookId);
+    const actor = this.resolveActor(user, input.anonymousId);
+    return this.likeBookUseCase.execute(actor, input.bookId);
   }
 
   @Mutation(() => Int)
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(OptionalGqlAuthGuard)
   async unlikeBook(
-    @CurrentUser() user: { id: string },
+    @CurrentUser() user: { id: string } | undefined,
     @Args('input') input: LikeBookInput,
   ): Promise<number> {
-    return this.unlikeBookUseCase.execute(user.id, input.bookId);
+    const actor = this.resolveActor(user, input.anonymousId);
+    return this.unlikeBookUseCase.execute(actor, input.bookId);
   }
 
   @Query(() => [Int])
-  @UseGuards(GqlAuthGuard)
-  async myLikedBookIds(@CurrentUser() user: { id: string }): Promise<number[]> {
-    return this.getMyLikedBookIdsUseCase.execute(user.id);
+  @UseGuards(OptionalGqlAuthGuard)
+  async myLikedBookIds(
+    @CurrentUser() user: { id: string } | undefined,
+    @Args('anonymousId', { type: () => String, nullable: true })
+    anonymousId?: string,
+  ): Promise<number[]> {
+    if (user?.id) {
+      return this.getMyLikedBookIdsUseCase.execute({
+        kind: 'user',
+        userId: user.id,
+      });
+    }
+    if (anonymousId) {
+      return this.getMyLikedBookIdsUseCase.execute({
+        kind: 'anonymous',
+        anonymousId,
+      });
+    }
+    return [];
+  }
+
+  /** ログインユーザーは userId、未ログインは anonymousId から操作主体を決定する */
+  private resolveActor(
+    user: { id: string } | undefined,
+    anonymousId?: string,
+  ): LikeActor {
+    if (user?.id) return { kind: 'user', userId: user.id };
+    if (anonymousId) return { kind: 'anonymous', anonymousId };
+    throw new BadRequestException(
+      'anonymousId is required for unauthenticated like',
+    );
   }
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -225,7 +225,7 @@ type Query {
   followInfo(input: GetFollowInfoInput!): FollowInfoResponse!
   followCounts(input: GetFollowInfoInput!): FollowInfoResponse!
   feed(input: GetFeedInput!): FeedResponse!
-  myLikedBookIds: [Int!]!
+  myLikedBookIds(anonymousId: String): [Int!]!
   notifications(input: GetNotificationsInput!): NotificationResponse!
   unreadNotificationCount: Int!
   popularBooks(limit: Int): [PopularBookItem!]!
@@ -429,6 +429,7 @@ input FollowUserInput {
 
 input LikeBookInput {
   bookId: Int!
+  anonymousId: String
 }
 
 input CreatePurchaseInput {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -149,14 +149,16 @@ model Follow {
 }
 
 model Like {
-  id      Int      @id @default(autoincrement()) @db.UnsignedInt
-  userId  String   @map("user_id")
-  bookId  Int      @map("book_id")
-  created DateTime @default(now()) @db.DateTime(0)
-  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  book    books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  id          Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId      String?  @map("user_id")
+  anonymousId String?  @map("anonymous_id") @db.VarChar(64)
+  bookId      Int      @map("book_id")
+  created     DateTime @default(now()) @db.DateTime(0)
+  user        User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book        books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
 
   @@unique([userId, bookId], map: "uniq_user_book")
+  @@unique([anonymousId, bookId], map: "uniq_anon_book")
   @@index([bookId])
   @@map("likes")
 }
@@ -180,15 +182,16 @@ model Purchase {
 }
 
 model Notification {
-  id      Int      @id @default(autoincrement()) @db.UnsignedInt
-  userId  String   @map("user_id")
-  actorId String   @map("actor_id")
-  type    String   @db.VarChar(20)
-  bookId  Int?     @map("book_id")
-  read    Boolean  @default(false)
-  created DateTime @default(now()) @db.DateTime(0)
-  user    User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
-  actor   User     @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
+  id               Int      @id @default(autoincrement()) @db.UnsignedInt
+  userId           String   @map("user_id")
+  actorId          String?  @map("actor_id")
+  actorAnonymousId String?  @map("actor_anonymous_id") @db.VarChar(64)
+  type             String   @db.VarChar(20)
+  bookId           Int?     @map("book_id")
+  read             Boolean  @default(false)
+  created          DateTime @default(now()) @db.DateTime(0)
+  user             User     @relation("notificationUser", fields: [userId], references: [id], onDelete: Cascade)
+  actor            User?    @relation("notificationActor", fields: [actorId], references: [id], onDelete: Cascade)
 
   @@unique([userId, actorId, type, bookId], map: "uniq_user_actor_type_book")
   @@index([userId])

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -24,6 +24,7 @@ import { useQuery } from '@apollo/client'
 import { myLikedBookIdsQuery } from '@/features/social/api'
 import { LikeButton } from '@/features/social/components/LikeButton'
 import { useCachedSession } from '@/hooks/useCachedSession'
+import { useAnonymousId } from '@/hooks/useAnonymousId'
 import {
   isSuiPaymentEnabled,
   mistToSui,
@@ -44,12 +45,16 @@ interface Props {
 export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
   const isMine = useIsBookOwner(book)
   const { status } = useCachedSession()
+  const anonymousId = useAnonymousId()
   const [suiOpen, setSuiOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
-  // ログイン中はいいね済みの本IDを取得し、初期状態を反映する
+  // いいね済みの本IDを取得し初期状態を反映する。
+  // ログイン中はユーザーの、未ログイン中は匿名IDのいいね済みを取得する。
+  const isAuthed = status === 'authenticated'
   const { data: likedData } = useQuery(myLikedBookIdsQuery, {
-    skip: status !== 'authenticated',
+    variables: { anonymousId: isAuthed ? undefined : anonymousId },
+    skip: !isAuthed && !anonymousId,
   })
   const likedBookIds: number[] = likedData?.myLikedBookIds ?? []
 

--- a/apps/web/src/features/social/api/queries.ts
+++ b/apps/web/src/features/social/api/queries.ts
@@ -26,8 +26,8 @@ export const topReadersQuery = gql`
 `
 
 export const myLikedBookIdsQuery = gql`
-  query MyLikedBookIds {
-    myLikedBookIds
+  query MyLikedBookIds($anonymousId: String) {
+    myLikedBookIds(anonymousId: $anonymousId)
   }
 `
 

--- a/apps/web/src/features/social/components/DiscoverPage.tsx
+++ b/apps/web/src/features/social/components/DiscoverPage.tsx
@@ -5,6 +5,7 @@ import { FaRegHeart } from 'react-icons/fa'
 import { Container } from '@/components/layout/Container'
 import { TitleWithLine } from '@/components/label/TitleWithLine'
 import { useCachedSession } from '@/hooks/useCachedSession'
+import { useAnonymousId } from '@/hooks/useAnonymousId'
 import { NO_IMAGE } from '@/libs/constants'
 import {
   popularBooksQuery,
@@ -47,6 +48,7 @@ export const DiscoverPage: React.FC = () => {
   const { session, status } = useCachedSession()
   const isAuthed = status === 'authenticated'
   const currentUsername = session?.user?.name ?? null
+  const anonymousId = useAnonymousId()
 
   const { data: popularData } = useQuery(popularBooksQuery, {
     variables: { limit: 12 },
@@ -54,8 +56,10 @@ export const DiscoverPage: React.FC = () => {
   const { data: readersData } = useQuery(topReadersQuery, {
     variables: { limit: 10 },
   })
+  // ログイン中はユーザーの、未ログイン中は匿名IDのいいね済み本を取得する
   const { data: likedData } = useQuery(myLikedBookIdsQuery, {
-    skip: !isAuthed,
+    variables: { anonymousId: isAuthed ? undefined : anonymousId },
+    skip: !isAuthed && !anonymousId,
   })
   const { data: feedData } = useQuery(feedQuery, {
     variables: { input: { limit: 12, offset: 0 } },

--- a/apps/web/src/features/social/components/LikeButton.tsx
+++ b/apps/web/src/features/social/components/LikeButton.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { FaHeart, FaRegHeart } from 'react-icons/fa'
-import { useAtom } from 'jotai'
-import { openLoginModalAtom } from '@/store/modal/atom'
 import { useCachedSession } from '@/hooks/useCachedSession'
+import { getOrCreateAnonymousId } from '@/libs/anonymousId'
 import { likeBookMutation, unlikeBookMutation } from '../api'
 
 interface Props {
@@ -21,7 +20,6 @@ export const LikeButton: React.FC<Props> = ({
   size = 18,
 }) => {
   const { status } = useCachedSession()
-  const [, setOpenLogin] = useAtom(openLoginModalAtom)
   const [liked, setLiked] = useState(initialLiked)
   const [count, setCount] = useState(initialCount)
   const [busy, setBusy] = useState(false)
@@ -31,10 +29,6 @@ export const LikeButton: React.FC<Props> = ({
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (status !== 'authenticated') {
-      setOpenLogin(true)
-      return
-    }
     if (busy) return
     setBusy(true)
     const next = !liked
@@ -42,7 +36,10 @@ export const LikeButton: React.FC<Props> = ({
     setLiked(next)
     setCount((c) => Math.max(0, c + (next ? 1 : -1)))
     try {
-      const input = { bookId: Number(bookId) }
+      // 未ログインユーザーは Cookie の匿名IDでいいねする
+      const anonymousId =
+        status === 'authenticated' ? undefined : getOrCreateAnonymousId()
+      const input = { bookId: Number(bookId), anonymousId }
       if (next) {
         const res = await like({ variables: { input } })
         setCount(res.data.likeBook)

--- a/apps/web/src/hooks/useAnonymousId.ts
+++ b/apps/web/src/hooks/useAnonymousId.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+import { getOrCreateAnonymousId } from '@/libs/anonymousId'
+
+/**
+ * 未ログインユーザーの匿名ID（Cookie由来）を返すフック。
+ * SSR とのハイドレーション不整合を避けるため、マウント後に値を確定する。
+ * 確定前は null を返す。
+ */
+export function useAnonymousId(): string | null {
+  const [anonymousId, setAnonymousId] = useState<string | null>(null)
+
+  useEffect(() => {
+    setAnonymousId(getOrCreateAnonymousId())
+  }, [])
+
+  return anonymousId
+}

--- a/apps/web/src/libs/anonymousId.ts
+++ b/apps/web/src/libs/anonymousId.ts
@@ -1,0 +1,30 @@
+/**
+ * 未ログインユーザーを識別するための匿名ID。
+ * Cookie に保存し、いいねの重複防止・取り消し・いいね済み表示に利用する。
+ */
+const COOKIE_NAME = 'kidoku_anon_id'
+const ONE_YEAR_SEC = 60 * 60 * 24 * 365
+
+const readCookie = (name: string): string | null => {
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(
+    new RegExp('(?:^|; )' + name + '=([^;]*)')
+  )
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+/**
+ * 匿名IDを取得する。未発行ならCookieに新規発行して返す。
+ * サーバーサイドでは空文字を返す（呼び出し側でクライアント判定すること）。
+ */
+export const getOrCreateAnonymousId = (): string => {
+  if (typeof document === 'undefined') return ''
+  const existing = readCookie(COOKIE_NAME)
+  if (existing) return existing
+  const id =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  document.cookie = `${COOKIE_NAME}=${id}; path=/; max-age=${ONE_YEAR_SEC}; SameSite=Lax`
+  return id
+}


### PR DESCRIPTION
未ログインユーザーが Cookie 由来の匿名IDでいいね・取り消しできるようにした。

## バックエンド
- likes.user_id を nullable にし anonymous_id を追加（[anonymous_id, book_id] にユニーク制約）
- ILikeRepository を LikeActor（user / anonymous）ベースの API に変更
- likeBook / unlikeBook / myLikedBookIds から GqlAuthGuard を外し、
  任意認証用の OptionalGqlAuthGuard を導入。未ログイン時は input/引数の
  anonymousId で操作主体を識別する
- notifications.actor_id を nullable 化し actor_anonymous_id を追加。
  匿名いいねは本の所有者へ「匿名ユーザー」として通知する
  （NULL を含むユニーク制約の都合で匿名分は明示的に検索→集約）

## フロントエンド
- LikeButton: 未ログイン時のログインモーダル誘導を廃止し、
  Cookie の匿名IDでいいね・取り消しを行う
- 匿名ID管理用の libs/anonymousId.ts と useAnonymousId フックを追加
- DiscoverPage / BookDetailReadModal: 未ログイン時は匿名IDで
  いいね済み状態を取得して初期表示に反映

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NLmnKL9x5HcyBzhGum5qF8