### PR TITLE
feat: 本の感想に他ユーザーがコメントできる機能を追加

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -42,6 +42,7 @@ model books {
   yearly_top_books YearlyTopBook[]
   likes            Like[]
   purchases        Purchase[]
+  bookComments     BookComment[]
 }
 
 model Account {
@@ -94,6 +95,7 @@ model User {
   notifications      Notification[] @relation("notificationUser")
   actorNotifications Notification[] @relation("notificationActor")
   purchases          Purchase[]
+  bookComments       BookComment[]
 
   @@map("users")
 }
@@ -209,4 +211,19 @@ model template_books {
   created        DateTime @default(now()) @db.DateTime(0)
   updated        DateTime @default(now()) @db.DateTime(0)
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model BookComment {
+  id      Int      @id @default(autoincrement()) @db.UnsignedInt
+  bookId  Int      @map("book_id")
+  userId  String   @map("user_id")
+  content String   @db.Text
+  created DateTime @default(now()) @db.DateTime(0)
+  updated DateTime @default(now()) @db.DateTime(0)
+  book    books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([bookId])
+  @@index([userId])
+  @@map("book_comments")
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { DatabaseModule } from './infrastructure/database/database.module';
 import { SoftwareDesignModule } from './presentation/modules/software-design';
 import { SheetModule } from './presentation/modules/sheet';
 import { CommentModule } from './presentation/modules/comment';
+import { BookCommentModule } from './presentation/modules/book-comment';
 import { BookModule } from './presentation/modules/book';
 import { SearchModule } from './presentation/modules/search';
 import { YearlyTopBookModule } from './presentation/modules/yearly-top-book';
@@ -40,6 +41,7 @@ import { PurchaseModule } from './presentation/modules/purchase';
     DatabaseModule,
     SheetModule,
     CommentModule,
+    BookCommentModule,
     SoftwareDesignModule,
     BookModule,
     SearchModule,

--- a/apps/api/src/application/usecases/book-comments/create-book-comment.spec.ts
+++ b/apps/api/src/application/usecases/book-comments/create-book-comment.spec.ts
@@ -1,0 +1,79 @@
+import { CreateBookCommentUseCase } from './create-book-comment';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+import { INotificationRepository } from '../../../domain/repositories/notification';
+import { BookComment } from '../../../domain/models/book-comment';
+
+describe('CreateBookCommentUseCase', () => {
+  let useCase: CreateBookCommentUseCase;
+  let mockRepo: jest.Mocked<IBookCommentRepository>;
+  let mockNotificationRepo: jest.Mocked<INotificationRepository>;
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn(),
+      findByBook: jest.fn(),
+      delete: jest.fn(),
+      countByBook: jest.fn(),
+    } as unknown as jest.Mocked<IBookCommentRepository>;
+    mockNotificationRepo = {
+      create: jest.fn(),
+      findByUser: jest.fn(),
+      countUnread: jest.fn(),
+      markAllRead: jest.fn(),
+    } as unknown as jest.Mocked<INotificationRepository>;
+
+    useCase = new CreateBookCommentUseCase(mockRepo, mockNotificationRepo);
+  });
+
+  it('コメントを作成し、本の所有者に通知を送る', async () => {
+    const saved = BookComment.fromDatabase(
+      1,
+      10,
+      'commenter',
+      'いいね',
+      new Date(),
+      new Date(),
+      'コメント太郎',
+      null,
+    );
+    mockRepo.create.mockResolvedValue({
+      comment: saved,
+      bookOwnerId: 'owner',
+    });
+
+    const result = await useCase.execute('commenter', 10, 'いいね');
+
+    expect(result).toBe(saved);
+    expect(mockNotificationRepo.create).toHaveBeenCalledWith({
+      userId: 'owner',
+      actorId: 'commenter',
+      type: 'comment',
+      bookId: 10,
+    });
+  });
+
+  it('本の所有者が取得できない場合は通知を送らない', async () => {
+    const saved = BookComment.fromDatabase(
+      1,
+      10,
+      'commenter',
+      'いいね',
+      new Date(),
+      new Date(),
+      'コメント太郎',
+      null,
+    );
+    mockRepo.create.mockResolvedValue({ comment: saved, bookOwnerId: null });
+
+    await useCase.execute('commenter', 10, 'いいね');
+
+    expect(mockNotificationRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('不正な内容はドメインバリデーションで弾かれる', async () => {
+    await expect(useCase.execute('commenter', 10, '   ')).rejects.toThrow(
+      'コメントを入力してください',
+    );
+    expect(mockRepo.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/application/usecases/book-comments/create-book-comment.ts
+++ b/apps/api/src/application/usecases/book-comments/create-book-comment.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { BookComment } from '../../../domain/models/book-comment';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+import { INotificationRepository } from '../../../domain/repositories/notification';
+
+@Injectable()
+export class CreateBookCommentUseCase {
+  constructor(
+    private readonly bookCommentRepository: IBookCommentRepository,
+    private readonly notificationRepository: INotificationRepository,
+  ) {}
+
+  async execute(
+    userId: string,
+    bookId: number,
+    content: string,
+  ): Promise<BookComment> {
+    const comment = BookComment.create({ userId, bookId, content });
+    const { comment: created, bookOwnerId } =
+      await this.bookCommentRepository.create(comment);
+
+    // 本の所有者にコメント通知を送る（自分の本へのコメントは通知されない）
+    if (bookOwnerId) {
+      await this.notificationRepository.create({
+        userId: bookOwnerId,
+        actorId: userId,
+        type: 'comment',
+        bookId,
+      });
+    }
+
+    return created;
+  }
+}

--- a/apps/api/src/application/usecases/book-comments/delete-book-comment.spec.ts
+++ b/apps/api/src/application/usecases/book-comments/delete-book-comment.spec.ts
@@ -1,0 +1,31 @@
+import { DeleteBookCommentUseCase } from './delete-book-comment';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+
+describe('DeleteBookCommentUseCase', () => {
+  let useCase: DeleteBookCommentUseCase;
+  let mockRepo: jest.Mocked<IBookCommentRepository>;
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn(),
+      findByBook: jest.fn(),
+      delete: jest.fn(),
+      countByBook: jest.fn(),
+    } as unknown as jest.Mocked<IBookCommentRepository>;
+
+    useCase = new DeleteBookCommentUseCase(mockRepo);
+  });
+
+  it('削除可能な場合は true を返す', async () => {
+    mockRepo.delete.mockResolvedValue(true);
+    const result = await useCase.execute('user-1', 5);
+    expect(result).toBe(true);
+    expect(mockRepo.delete).toHaveBeenCalledWith(5, 'user-1');
+  });
+
+  it('権限がない場合は false を返す', async () => {
+    mockRepo.delete.mockResolvedValue(false);
+    const result = await useCase.execute('user-1', 5);
+    expect(result).toBe(false);
+  });
+});

--- a/apps/api/src/application/usecases/book-comments/delete-book-comment.ts
+++ b/apps/api/src/application/usecases/book-comments/delete-book-comment.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+
+@Injectable()
+export class DeleteBookCommentUseCase {
+  constructor(private readonly bookCommentRepository: IBookCommentRepository) {}
+
+  async execute(userId: string, commentId: number): Promise<boolean> {
+    return this.bookCommentRepository.delete(commentId, userId);
+  }
+}

--- a/apps/api/src/application/usecases/book-comments/get-book-comments.spec.ts
+++ b/apps/api/src/application/usecases/book-comments/get-book-comments.spec.ts
@@ -1,0 +1,43 @@
+import { GetBookCommentsUseCase } from './get-book-comments';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+import { BookComment } from '../../../domain/models/book-comment';
+
+describe('GetBookCommentsUseCase', () => {
+  let useCase: GetBookCommentsUseCase;
+  let mockRepo: jest.Mocked<IBookCommentRepository>;
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn(),
+      findByBook: jest.fn(),
+      delete: jest.fn(),
+      countByBook: jest.fn(),
+    } as unknown as jest.Mocked<IBookCommentRepository>;
+
+    useCase = new GetBookCommentsUseCase(mockRepo);
+  });
+
+  it('指定した本のコメント一覧を返す', async () => {
+    const comment = BookComment.fromDatabase(
+      1,
+      10,
+      'user-1',
+      'コメント',
+      new Date(),
+      new Date(),
+      'ユーザー',
+      null,
+    );
+    mockRepo.findByBook.mockResolvedValue({
+      items: [comment],
+      total: 1,
+      hasMore: false,
+    });
+
+    const result = await useCase.execute(10, 20, 0);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(mockRepo.findByBook).toHaveBeenCalledWith(10, 20, 0);
+  });
+});

--- a/apps/api/src/application/usecases/book-comments/get-book-comments.ts
+++ b/apps/api/src/application/usecases/book-comments/get-book-comments.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { BookComment } from '../../../domain/models/book-comment';
+import { IBookCommentRepository } from '../../../domain/repositories/book-comment';
+import { PaginatedResult } from '../../../domain/types/paginated-result';
+
+@Injectable()
+export class GetBookCommentsUseCase {
+  constructor(private readonly bookCommentRepository: IBookCommentRepository) {}
+
+  async execute(
+    bookId: number,
+    limit: number,
+    offset: number,
+  ): Promise<PaginatedResult<BookComment>> {
+    return this.bookCommentRepository.findByBook(bookId, limit, offset);
+  }
+}

--- a/apps/api/src/domain/models/book-comment.spec.ts
+++ b/apps/api/src/domain/models/book-comment.spec.ts
@@ -1,0 +1,88 @@
+import { BookComment } from './book-comment';
+
+describe('BookComment', () => {
+  describe('create', () => {
+    it('有効な値でコメントを作成できる', () => {
+      const comment = BookComment.create({
+        bookId: 1,
+        userId: 'user-1',
+        content: '  面白かったです  ',
+      });
+
+      expect(comment.id).toBeNull();
+      expect(comment.bookId).toBe(1);
+      expect(comment.userId).toBe('user-1');
+      // 前後の空白はトリミングされる
+      expect(comment.content).toBe('面白かったです');
+    });
+
+    it('空文字のコメントはエラー', () => {
+      expect(() =>
+        BookComment.create({ bookId: 1, userId: 'user-1', content: '   ' }),
+      ).toThrow('コメントを入力してください');
+    });
+
+    it('最大文字数を超えるコメントはエラー', () => {
+      const longContent = 'a'.repeat(BookComment.MAX_CONTENT_LENGTH + 1);
+      expect(() =>
+        BookComment.create({
+          bookId: 1,
+          userId: 'user-1',
+          content: longContent,
+        }),
+      ).toThrow('コメントは1000文字以内で入力してください');
+    });
+
+    it('書籍IDが不正な場合はエラー', () => {
+      expect(() =>
+        BookComment.create({ bookId: 0, userId: 'user-1', content: 'test' }),
+      ).toThrow('書籍IDが不正です');
+    });
+
+    it('ユーザーIDが空の場合はエラー', () => {
+      expect(() =>
+        BookComment.create({ bookId: 1, userId: '', content: 'test' }),
+      ).toThrow('ユーザーIDは必須です');
+    });
+  });
+
+  describe('fromDatabase', () => {
+    it('DBからの復元ができる', () => {
+      const created = new Date('2025-06-01');
+      const updated = new Date('2025-06-02');
+      const comment = BookComment.fromDatabase(
+        10,
+        1,
+        'user-1',
+        'コメント本文',
+        created,
+        updated,
+        'テストユーザー',
+        'avatar.jpg',
+      );
+
+      expect(comment.id).toBe(10);
+      expect(comment.bookId).toBe(1);
+      expect(comment.userId).toBe('user-1');
+      expect(comment.content).toBe('コメント本文');
+      expect(comment.created).toBe(created);
+      expect(comment.updated).toBe(updated);
+      expect(comment.username).toBe('テストユーザー');
+      expect(comment.userImage).toBe('avatar.jpg');
+    });
+
+    it('userImageがnullでも復元できる', () => {
+      const comment = BookComment.fromDatabase(
+        10,
+        1,
+        'user-1',
+        'コメント',
+        new Date(),
+        new Date(),
+        'ユーザー',
+        null,
+      );
+      expect(comment.userImage).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/domain/models/book-comment.ts
+++ b/apps/api/src/domain/models/book-comment.ts
@@ -1,0 +1,99 @@
+export class BookComment {
+  static readonly MAX_CONTENT_LENGTH = 1000;
+
+  private constructor(
+    private readonly _id: number | null,
+    private readonly _bookId: number,
+    private readonly _userId: string,
+    private _content: string,
+    private readonly _created: Date,
+    private _updated: Date,
+    private readonly _username: string,
+    private readonly _userImage: string | null,
+  ) {}
+
+  get id(): number | null {
+    return this._id;
+  }
+  get bookId(): number {
+    return this._bookId;
+  }
+  get userId(): string {
+    return this._userId;
+  }
+  get content(): string {
+    return this._content;
+  }
+  get created(): Date {
+    return this._created;
+  }
+  get updated(): Date {
+    return this._updated;
+  }
+  get username(): string {
+    return this._username;
+  }
+  get userImage(): string | null {
+    return this._userImage;
+  }
+
+  private static validateContent(content: string): string {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+      throw new Error('コメントを入力してください');
+    }
+    if (trimmed.length > BookComment.MAX_CONTENT_LENGTH) {
+      throw new Error(
+        `コメントは${BookComment.MAX_CONTENT_LENGTH}文字以内で入力してください`,
+      );
+    }
+    return trimmed;
+  }
+
+  static create(params: {
+    bookId: number;
+    userId: string;
+    content: string;
+  }): BookComment {
+    if (!params.bookId || params.bookId <= 0) {
+      throw new Error('書籍IDが不正です');
+    }
+    if (!params.userId) {
+      throw new Error('ユーザーIDは必須です');
+    }
+    const content = BookComment.validateContent(params.content);
+    const now = new Date();
+    return new BookComment(
+      null,
+      params.bookId,
+      params.userId,
+      content,
+      now,
+      now,
+      '',
+      null,
+    );
+  }
+
+  static fromDatabase(
+    id: number,
+    bookId: number,
+    userId: string,
+    content: string,
+    created: Date,
+    updated: Date,
+    username: string,
+    userImage: string | null,
+  ): BookComment {
+    return new BookComment(
+      id,
+      bookId,
+      userId,
+      content,
+      created,
+      updated,
+      username,
+      userImage,
+    );
+  }
+}

--- a/apps/api/src/domain/repositories/book-comment.ts
+++ b/apps/api/src/domain/repositories/book-comment.ts
@@ -1,0 +1,22 @@
+import { BookComment } from '../models/book-comment';
+import { PaginatedResult } from '../types/paginated-result';
+
+export abstract class IBookCommentRepository {
+  /** コメントを作成し、作成されたコメントと本の所有者IDを返す */
+  abstract create(
+    comment: BookComment,
+  ): Promise<{ comment: BookComment; bookOwnerId: string | null }>;
+
+  /** 指定した本のコメント一覧を新しい順に取得する */
+  abstract findByBook(
+    bookId: number,
+    limit: number,
+    offset: number,
+  ): Promise<PaginatedResult<BookComment>>;
+
+  /** コメントを削除する。削除できた場合は true を返す */
+  abstract delete(id: number, userId: string): Promise<boolean>;
+
+  /** 指定した本のコメント件数を返す */
+  abstract countByBook(bookId: number): Promise<number>;
+}

--- a/apps/api/src/domain/repositories/notification.ts
+++ b/apps/api/src/domain/repositories/notification.ts
@@ -4,7 +4,7 @@ import { NotificationItem } from '../types/social';
 export interface CreateNotificationParams {
   userId: string;
   actorId: string;
-  type: 'follow' | 'like';
+  type: 'follow' | 'like' | 'comment';
   bookId?: number | null;
 }
 

--- a/apps/api/src/infrastructure/repositories/book-comment.ts
+++ b/apps/api/src/infrastructure/repositories/book-comment.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../database/prisma.service';
+import { BookComment } from '../../domain/models/book-comment';
+import { IBookCommentRepository } from '../../domain/repositories/book-comment';
+import { PaginatedResult } from '../../domain/types/paginated-result';
+
+@Injectable()
+export class BookCommentRepository implements IBookCommentRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    comment: BookComment,
+  ): Promise<{ comment: BookComment; bookOwnerId: string | null }> {
+    const book = await this.prisma.books.findUnique({
+      where: { id: comment.bookId },
+      select: { userId: true },
+    });
+    if (!book) {
+      throw new Error('書籍が見つかりません');
+    }
+
+    const created = await this.prisma.bookComment.create({
+      data: {
+        bookId: comment.bookId,
+        userId: comment.userId,
+        content: comment.content,
+      },
+      select: {
+        id: true,
+        bookId: true,
+        userId: true,
+        content: true,
+        created: true,
+        updated: true,
+        user: { select: { name: true, image: true } },
+      },
+    });
+
+    return {
+      comment: BookComment.fromDatabase(
+        created.id,
+        created.bookId,
+        created.userId,
+        created.content,
+        created.created,
+        created.updated,
+        created.user.name || '',
+        created.user.image || null,
+      ),
+      bookOwnerId: book.userId,
+    };
+  }
+
+  async findByBook(
+    bookId: number,
+    limit = 20,
+    offset = 0,
+  ): Promise<PaginatedResult<BookComment>> {
+    const [results, total] = await Promise.all([
+      this.prisma.bookComment.findMany({
+        where: { bookId },
+        select: {
+          id: true,
+          bookId: true,
+          userId: true,
+          content: true,
+          created: true,
+          updated: true,
+          user: { select: { name: true, image: true } },
+        },
+        orderBy: { created: 'desc' },
+        take: limit + 1,
+        skip: offset,
+      }),
+      this.prisma.bookComment.count({ where: { bookId } }),
+    ]);
+
+    const hasMore = results.length > limit;
+    const page = hasMore ? results.slice(0, limit) : results;
+
+    const items = page.map((c) =>
+      BookComment.fromDatabase(
+        c.id,
+        c.bookId,
+        c.userId,
+        c.content,
+        c.created,
+        c.updated,
+        c.user.name || '',
+        c.user.image || null,
+      ),
+    );
+
+    return { items, hasMore, total };
+  }
+
+  async delete(id: number, userId: string): Promise<boolean> {
+    const comment = await this.prisma.bookComment.findUnique({
+      where: { id },
+      select: { userId: true, book: { select: { userId: true } } },
+    });
+    if (!comment) return false;
+
+    // コメント投稿者または本の所有者のみ削除可能
+    const isAuthor = comment.userId === userId;
+    const isBookOwner = comment.book.userId === userId;
+    if (!isAuthor && !isBookOwner) return false;
+
+    await this.prisma.bookComment.delete({ where: { id } });
+    return true;
+  }
+
+  async countByBook(bookId: number): Promise<number> {
+    return this.prisma.bookComment.count({ where: { bookId } });
+  }
+}

--- a/apps/api/src/presentation/dto/book-comment.ts
+++ b/apps/api/src/presentation/dto/book-comment.ts
@@ -1,0 +1,69 @@
+import {
+  Field,
+  ObjectType,
+  InputType,
+  ID,
+  Int,
+  GraphQLISODateTime,
+} from '@nestjs/graphql';
+import { PaginatedResponse } from './paginated';
+
+@InputType()
+export class GetBookCommentsInput {
+  @Field(() => Int)
+  bookId: number;
+
+  @Field(() => Int, { defaultValue: 20 })
+  limit: number;
+
+  @Field(() => Int, { defaultValue: 0 })
+  offset: number;
+}
+
+@InputType()
+export class CreateBookCommentInput {
+  @Field(() => Int)
+  bookId: number;
+
+  @Field()
+  content: string;
+}
+
+@InputType()
+export class DeleteBookCommentInput {
+  @Field(() => Int)
+  id: number;
+}
+
+@ObjectType()
+export class BookCommentItem {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => Int)
+  bookId: number;
+
+  @Field()
+  userId: string;
+
+  @Field()
+  content: string;
+
+  @Field(() => GraphQLISODateTime)
+  created: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updated: Date;
+
+  @Field()
+  username: string;
+
+  @Field({ nullable: true })
+  userImage?: string;
+}
+
+@ObjectType()
+export class BookCommentsResponse extends PaginatedResponse {
+  @Field(() => [BookCommentItem])
+  comments: BookCommentItem[];
+}

--- a/apps/api/src/presentation/modules/book-comment.ts
+++ b/apps/api/src/presentation/modules/book-comment.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { BookCommentResolver } from '../resolvers/book-comment';
+import { AuthModule } from '../../infrastructure/auth/auth.module';
+import { BookCommentRepository } from '../../infrastructure/repositories/book-comment';
+import { NotificationRepository } from '../../infrastructure/repositories/notification';
+import { IBookCommentRepository } from '../../domain/repositories/book-comment';
+import { INotificationRepository } from '../../domain/repositories/notification';
+import { CreateBookCommentUseCase } from '../../application/usecases/book-comments/create-book-comment';
+import { GetBookCommentsUseCase } from '../../application/usecases/book-comments/get-book-comments';
+import { DeleteBookCommentUseCase } from '../../application/usecases/book-comments/delete-book-comment';
+
+@Module({
+  imports: [AuthModule],
+  providers: [
+    BookCommentResolver,
+    CreateBookCommentUseCase,
+    GetBookCommentsUseCase,
+    DeleteBookCommentUseCase,
+    {
+      provide: IBookCommentRepository,
+      useClass: BookCommentRepository,
+    },
+    {
+      provide: INotificationRepository,
+      useClass: NotificationRepository,
+    },
+  ],
+})
+export class BookCommentModule {}

--- a/apps/api/src/presentation/resolvers/book-comment.ts
+++ b/apps/api/src/presentation/resolvers/book-comment.ts
@@ -1,0 +1,76 @@
+import { UseGuards } from '@nestjs/common';
+import { Query, Mutation, Resolver, Args } from '@nestjs/graphql';
+import { GqlAuthGuard } from '../../infrastructure/auth/gql-auth.guard';
+import { CurrentUser } from '../../infrastructure/auth/current-user.decorator';
+import { CreateBookCommentUseCase } from '../../application/usecases/book-comments/create-book-comment';
+import { GetBookCommentsUseCase } from '../../application/usecases/book-comments/get-book-comments';
+import { DeleteBookCommentUseCase } from '../../application/usecases/book-comments/delete-book-comment';
+import {
+  BookCommentItem,
+  BookCommentsResponse,
+  CreateBookCommentInput,
+  DeleteBookCommentInput,
+  GetBookCommentsInput,
+} from '../dto/book-comment';
+import { BookComment } from '../../domain/models/book-comment';
+
+@Resolver()
+export class BookCommentResolver {
+  constructor(
+    private readonly createBookCommentUseCase: CreateBookCommentUseCase,
+    private readonly getBookCommentsUseCase: GetBookCommentsUseCase,
+    private readonly deleteBookCommentUseCase: DeleteBookCommentUseCase,
+  ) {}
+
+  @Query(() => BookCommentsResponse)
+  async bookComments(
+    @Args('input') input: GetBookCommentsInput,
+  ): Promise<BookCommentsResponse> {
+    const result = await this.getBookCommentsUseCase.execute(
+      input.bookId,
+      input.limit,
+      input.offset,
+    );
+    return {
+      comments: result.items.map((item) => this.toItem(item)),
+      total: result.total,
+      hasMore: result.hasMore,
+    };
+  }
+
+  @Mutation(() => BookCommentItem)
+  @UseGuards(GqlAuthGuard)
+  async createBookComment(
+    @CurrentUser() user: { id: string },
+    @Args('input') input: CreateBookCommentInput,
+  ): Promise<BookCommentItem> {
+    const comment = await this.createBookCommentUseCase.execute(
+      user.id,
+      input.bookId,
+      input.content,
+    );
+    return this.toItem(comment);
+  }
+
+  @Mutation(() => Boolean)
+  @UseGuards(GqlAuthGuard)
+  async deleteBookComment(
+    @CurrentUser() user: { id: string },
+    @Args('input') input: DeleteBookCommentInput,
+  ): Promise<boolean> {
+    return this.deleteBookCommentUseCase.execute(user.id, input.id);
+  }
+
+  private toItem(comment: BookComment): BookCommentItem {
+    return {
+      id: String(comment.id),
+      bookId: comment.bookId,
+      userId: comment.userId,
+      content: comment.content,
+      created: comment.created,
+      updated: comment.updated,
+      username: comment.username,
+      userImage: comment.userImage ?? undefined,
+    };
+  }
+}

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -50,6 +50,23 @@ type CommentResponse {
   comments: [CommentItem!]!
 }
 
+type BookCommentItem {
+  id: ID!
+  bookId: Int!
+  userId: String!
+  content: String!
+  created: DateTime!
+  updated: DateTime!
+  username: String!
+  userImage: String
+}
+
+type BookCommentsResponse {
+  total: Float!
+  hasMore: Boolean!
+  comments: [BookCommentItem!]!
+}
+
 type BookResponse {
   id: ID!
   userId: ID!
@@ -207,6 +224,7 @@ type PurchaseResponse {
 type Query {
   sheets: [SheetResponse!]!
   comments(input: GetCommentsInput!): CommentResponse!
+  bookComments(input: GetBookCommentsInput!): BookCommentsResponse!
   latestSoftwareDesign: SoftwareDesignResponse!
   softwareDesignByMonth(year: Int!, month: Int!): SoftwareDesignResponse!
   softwareDesignByYear(input: GetSoftwareDesignInput!): SoftwareDesignListResponse!
@@ -238,6 +256,12 @@ type Query {
 input GetCommentsInput {
   limit: Int!
   offset: Int!
+}
+
+input GetBookCommentsInput {
+  bookId: Int!
+  limit: Int! = 20
+  offset: Int! = 0
 }
 
 input GetSoftwareDesignInput {
@@ -302,6 +326,8 @@ type Mutation {
   updateSheet(input: UpdateSheetInput!): SheetResponse!
   deleteSheet(input: DeleteSheetInput!): Boolean!
   updateSheetOrders(input: UpdateSheetOrdersInput!): Boolean!
+  createBookComment(input: CreateBookCommentInput!): BookCommentItem!
+  deleteBookComment(input: DeleteBookCommentInput!): Boolean!
   createBook(input: CreateBookInput!): BookResponse!
   updateBook(input: UpdateBookInput!): BookResponse!
   deleteBook(input: DeleteBookInput!): Boolean!
@@ -343,6 +369,15 @@ input UpdateSheetOrdersInput {
 input SheetOrderItem {
   id: ID!
   order: Int!
+}
+
+input CreateBookCommentInput {
+  bookId: Int!
+  content: String!
+}
+
+input DeleteBookCommentInput {
+  id: Int!
 }
 
 input CreateBookInput {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -42,6 +42,7 @@ model books {
   yearly_top_books YearlyTopBook[]
   likes            Like[]
   purchases        Purchase[]
+  bookComments     BookComment[]
 }
 
 model Account {
@@ -94,6 +95,7 @@ model User {
   notifications      Notification[] @relation("notificationUser")
   actorNotifications Notification[] @relation("notificationActor")
   purchases          Purchase[]
+  bookComments       BookComment[]
 
   @@map("users")
 }
@@ -209,4 +211,19 @@ model template_books {
   created        DateTime @default(now()) @db.DateTime(0)
   updated        DateTime @default(now()) @db.DateTime(0)
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model BookComment {
+  id      Int      @id @default(autoincrement()) @db.UnsignedInt
+  bookId  Int      @map("book_id")
+  userId  String   @map("user_id")
+  content String   @db.Text
+  created DateTime @default(now()) @db.DateTime(0)
+  updated DateTime @default(now()) @db.DateTime(0)
+  book    books    @relation(fields: [bookId], references: [id], onDelete: Cascade)
+  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([bookId])
+  @@index([userId])
+  @@map("book_comments")
 }

--- a/apps/web/src/features/books/api/comments.ts
+++ b/apps/web/src/features/books/api/comments.ts
@@ -1,0 +1,41 @@
+import { gql } from '@apollo/client'
+
+export const bookCommentsQuery = gql`
+  query BookComments($input: GetBookCommentsInput!) {
+    bookComments(input: $input) {
+      comments {
+        id
+        bookId
+        userId
+        content
+        created
+        updated
+        username
+        userImage
+      }
+      hasMore
+      total
+    }
+  }
+`
+
+export const createBookCommentMutation = gql`
+  mutation CreateBookComment($input: CreateBookCommentInput!) {
+    createBookComment(input: $input) {
+      id
+      bookId
+      userId
+      content
+      created
+      updated
+      username
+      userImage
+    }
+  }
+`
+
+export const deleteBookCommentMutation = gql`
+  mutation DeleteBookComment($input: DeleteBookCommentInput!) {
+    deleteBookComment(input: $input)
+  }
+`

--- a/apps/web/src/features/books/api/index.ts
+++ b/apps/web/src/features/books/api/index.ts
@@ -1,1 +1,2 @@
 export * from './queries'
+export * from './comments'

--- a/apps/web/src/features/books/components/BookPage.tsx
+++ b/apps/web/src/features/books/components/BookPage.tsx
@@ -154,6 +154,7 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
             book={book}
             onClose={handleClose}
             onEdit={isOwner ? handleEditToggle : undefined}
+            showComments
           />
         )}
       </div>

--- a/apps/web/src/features/books/components/CommentSection.tsx
+++ b/apps/web/src/features/books/components/CommentSection.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react'
+import { useMutation, useQuery } from '@apollo/client'
+import { useAtom } from 'jotai'
+import { FaRegTrashAlt } from 'react-icons/fa'
+import { openLoginModalAtom } from '@/store/modal/atom'
+import { useCachedSession } from '@/hooks/useCachedSession'
+import { getLastModified } from '@/utils/string'
+import { NO_IMAGE } from '@/libs/constants'
+import {
+  bookCommentsQuery,
+  createBookCommentMutation,
+  deleteBookCommentMutation,
+} from '../api'
+
+interface CommentItem {
+  id: string
+  bookId: number
+  userId: string
+  content: string
+  created: string
+  updated: string
+  username: string
+  userImage?: string | null
+}
+
+interface Props {
+  bookId: number | string
+  /** 本の所有者ID。投稿者本人に加えて本の所有者もコメントを削除できる */
+  bookOwnerId?: string
+}
+
+const MAX_LENGTH = 1000
+
+export const CommentSection: React.FC<Props> = ({ bookId, bookOwnerId }) => {
+  const numericBookId = Number(bookId)
+  const { session, status } = useCachedSession()
+  const isAuthed = status === 'authenticated'
+  const currentUserId = session?.user?.id
+  const [, setOpenLogin] = useAtom(openLoginModalAtom)
+  const [content, setContent] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const { data, loading, refetch } = useQuery(bookCommentsQuery, {
+    variables: { input: { bookId: numericBookId, limit: 50, offset: 0 } },
+    fetchPolicy: 'cache-and-network',
+  })
+  const [createComment] = useMutation(createBookCommentMutation)
+  const [deleteComment] = useMutation(deleteBookCommentMutation)
+
+  const comments: CommentItem[] = data?.bookComments?.comments ?? []
+  const total: number = data?.bookComments?.total ?? comments.length
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!isAuthed) {
+      setOpenLogin(true)
+      return
+    }
+    const trimmed = content.trim()
+    if (trimmed.length === 0 || submitting) return
+    setSubmitting(true)
+    try {
+      await createComment({
+        variables: { input: { bookId: numericBookId, content: trimmed } },
+      })
+      setContent('')
+      await refetch()
+    } catch {
+      // 失敗時は入力内容を残す
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('このコメントを削除しますか？')) return
+    try {
+      await deleteComment({ variables: { input: { id: Number(id) } } })
+      await refetch()
+    } catch {
+      // 失敗時は何もしない
+    }
+  }
+
+  const canDelete = (comment: CommentItem) =>
+    isAuthed &&
+    (comment.userId === currentUserId || bookOwnerId === currentUserId)
+
+  return (
+    <div className="px-4 pb-24">
+      <h2 className="mb-3 text-lg font-semibold text-gray-800">
+        コメント
+        {total > 0 && (
+          <span className="ml-2 text-sm font-normal text-gray-500">
+            {total}
+          </span>
+        )}
+      </h2>
+
+      {/* 投稿フォーム */}
+      <form onSubmit={handleSubmit} className="mb-6">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          maxLength={MAX_LENGTH}
+          rows={3}
+          placeholder={
+            isAuthed
+              ? 'この感想にコメントする'
+              : 'ログインするとコメントできます'
+          }
+          onFocusCapture={() => {
+            if (!isAuthed) setOpenLogin(true)
+          }}
+          className="w-full resize-none rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+        />
+        <div className="mt-2 flex items-center justify-between">
+          <span className="text-xs text-gray-400">
+            {content.length}/{MAX_LENGTH}
+          </span>
+          <button
+            type="submit"
+            disabled={submitting || content.trim().length === 0}
+            className="rounded-full bg-slate-800 px-5 py-2 text-sm font-bold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? '送信中...' : 'コメントする'}
+          </button>
+        </div>
+      </form>
+
+      {/* コメント一覧 */}
+      {loading && comments.length === 0 ? (
+        <p className="py-6 text-center text-sm text-gray-400">読み込み中...</p>
+      ) : comments.length === 0 ? (
+        <p className="py-6 text-center text-sm text-gray-400">
+          まだコメントはありません。最初のコメントを投稿してみましょう。
+        </p>
+      ) : (
+        <ul className="space-y-4">
+          {comments.map((comment) => (
+            <li key={comment.id} className="flex gap-3">
+              <img
+                src={comment.userImage || NO_IMAGE}
+                alt=""
+                className="h-9 w-9 flex-shrink-0 rounded-full object-cover"
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-gray-800">
+                    {comment.username}
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    {getLastModified(comment.created)}
+                  </span>
+                  {canDelete(comment) && (
+                    <button
+                      onClick={() => handleDelete(comment.id)}
+                      aria-label="コメントを削除"
+                      className="ml-auto text-gray-300 transition-colors hover:text-red-500"
+                    >
+                      <FaRegTrashAlt size={13} />
+                    </button>
+                  )}
+                </div>
+                <p className="mt-1 whitespace-pre-wrap break-words text-sm text-gray-700">
+                  {comment.content}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -34,14 +34,21 @@ import {
   bookPaymentRecipientQuery,
 } from '@/features/purchase/api'
 import { SuiLogo } from '@/components/icon/SuiLogo'
+import { CommentSection } from '@/features/books/components/CommentSection'
 
 interface Props {
   book: Book
   onClose: () => void
   onEdit?: () => void
+  /** 感想へのコメント欄を表示するか（書籍詳細ページでのみ有効化） */
+  showComments?: boolean
 }
 
-export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
+export const BookDetailReadModal: React.FC<Props> = ({
+  book,
+  onEdit,
+  showComments = false,
+}) => {
   const isMine = useIsBookOwner(book)
   const { status } = useCachedSession()
   const [suiOpen, setSuiOpen] = useState(false)
@@ -237,6 +244,10 @@ export const BookDetailReadModal: React.FC<Props> = ({ book, onEdit }) => {
               ))}
           </div>
         </div>
+
+        {showComments && (
+          <CommentSection bookId={book.id} bookOwnerId={book.user?.id} />
+        )}
       </div>
 
       {isSuiPaymentEnabled && suiRecipient && (

--- a/apps/web/src/features/social/components/NotificationsPage.tsx
+++ b/apps/web/src/features/social/components/NotificationsPage.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import Link from 'next/link'
 import { useMutation, useQuery } from '@apollo/client'
 import { NextSeo } from 'next-seo'
-import { FaHeart, FaUserPlus } from 'react-icons/fa'
+import { FaHeart, FaUserPlus, FaRegComment } from 'react-icons/fa'
 import { Container } from '@/components/layout/Container'
 import { useCachedSession } from '@/hooks/useCachedSession'
 import { getLastModified } from '@/utils/string'
@@ -72,6 +72,7 @@ export const NotificationsPage: React.FC = () => {
 
 const NotificationRow: React.FC<{ item: NotificationItem }> = ({ item }) => {
   const isFollow = item.type === 'follow'
+  const isComment = item.type === 'comment'
   const href =
     isFollow || !item.bookId
       ? `/${item.actorName}/sheets`
@@ -91,16 +92,27 @@ const NotificationRow: React.FC<{ item: NotificationItem }> = ({ item }) => {
         />
         <span
           className={`absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full text-white ${
-            isFollow ? 'bg-gray-700' : 'bg-pink-500'
+            isFollow ? 'bg-gray-700' : isComment ? 'bg-blue-500' : 'bg-pink-500'
           }`}
         >
-          {isFollow ? <FaUserPlus size={10} /> : <FaHeart size={10} />}
+          {isFollow ? (
+            <FaUserPlus size={10} />
+          ) : isComment ? (
+            <FaRegComment size={10} />
+          ) : (
+            <FaHeart size={10} />
+          )}
         </span>
       </div>
       <Link href={href} className="flex-1 text-sm hover:underline">
         <span className="font-bold">{item.actorName}</span>
         {isFollow ? (
           'さんがあなたをフォローしました'
+        ) : isComment ? (
+          <>
+            さんが「<span className="font-bold">{item.bookTitle}</span>
+            」にコメントしました
+          </>
         ) : (
           <>
             さんが「<span className="font-bold">{item.bookTitle}</span>


### PR DESCRIPTION
書籍詳細ページ（/books/[bookId]）の感想に対して、他のユーザーが
コメントを投稿・閲覧・削除できる機能を追加。

API (DDD レイヤード):
- BookComment ドメインモデル（バリデーション込み）
- IBookCommentRepository とその実装
- create / get / delete ユースケース
- GraphQL リゾルバー（bookComments クエリ、createBookComment /
  deleteBookComment ミューテーション）
- book_comments テーブルを両 Prisma スキーマに追加
- コメント時に本の所有者へ通知（notification type に 'comment' 追加）
- 削除はコメント投稿者または本の所有者のみ可能

Web:
- CommentSection コンポーネント（一覧 + 投稿フォーム）を
  BookDetailReadModal に showComments で組み込み
- 通知一覧にコメント種別の表示を追加

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018UkUaXVXzvX86zbFoHRhVz