### PR TITLE
Refactor memo fetching to prevent masked data in edit mode

### DIFF
--- a/apps/web/src/features/books/components/BookPage.tsx
+++ b/apps/web/src/features/books/components/BookPage.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { Book } from '@/types/book'
 import { BookDetailReadModal } from '@/features/sheet/components/BookDetailReadModal'
 import { BookDetailEditPage } from '@/features/sheet/components/BookDetailEditPage'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { MdChevronRight } from 'react-icons/md'
 import { useIsBookOwner } from '@/hooks/useIsBookOwner'
 import apolloClient from '@/libs/apollo'
@@ -27,25 +27,29 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
     setEditMode(false)
   }, [initialBook])
 
-  // 所有者の場合、GraphQL経由で完全なメモデータを取得
-  useEffect(() => {
-    if (!isOwner || !book) return
-    const fetchOwnerBook = async () => {
-      try {
-        const { data } = await apolloClient.query({
-          query: getBookQuery,
-          variables: { input: { id: String(book.id) } },
-          fetchPolicy: 'network-only',
-        })
-        if (data?.book?.memo !== undefined) {
-          setBook((prev) => ({ ...prev, memo: data.book.memo }))
-        }
-      } catch {
-        // フォールバック: ISRで生成されたデータをそのまま使用
+  // 所有者向けに、マスクされていない完全なメモをGraphQL経由で取得する。
+  // ISRで生成されるpropsのメモはマスク済み(*****)のため、所有者には元の
+  // メモ（[[MASK: ...]]アノテーション付き）を取得し直す必要がある。
+  const fetchOwnerMemo = useCallback(async () => {
+    if (!isOwner || !book?.id) return
+    try {
+      const { data } = await apolloClient.query({
+        query: getBookQuery,
+        variables: { input: { id: String(book.id) } },
+        fetchPolicy: 'network-only',
+      })
+      if (data?.book?.memo !== undefined) {
+        setBook((prev) => (prev ? { ...prev, memo: data.book.memo } : prev))
       }
+    } catch {
+      // フォールバック: ISRで生成されたデータをそのまま使用
     }
-    fetchOwnerBook()
   }, [isOwner, book?.id])
+
+  // 所有者の場合、ページ表示時に完全なメモデータを取得
+  useEffect(() => {
+    fetchOwnerMemo()
+  }, [fetchOwnerMemo])
 
   if (!book) {
     return (
@@ -69,8 +73,14 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
     router.back()
   }
 
-  const handleEditToggle = () => {
-    setEditMode(!editMode)
+  const handleEditToggle = async () => {
+    // 編集モードに入る際は、マスクされていない最新のメモを取得してから切り替える。
+    // ISR直後の再取得が完了する前に編集ボタンを押すと、マスク済みメモ(*****)が
+    // 編集フォームに表示されてしまうため、ここで取得完了を待つ。
+    if (!editMode) {
+      await fetchOwnerMemo()
+    }
+    setEditMode((prev) => !prev)
   }
 
   const sheetUrl =


### PR DESCRIPTION
## 概要

書籍詳細ページのメモ取得ロジックをリファクタリングしました。ISR生成時にマスクされたメモ(*****)が編集フォームに表示される問題を修正します。

### 変更内容

1. **`fetchOwnerMemo` を `useCallback` で抽出**
   - GraphQL経由でマスクされていない完全なメモを取得する処理を独立した関数に分離
   - 依存配列を `[isOwner, book?.id]` に最適化

2. **編集モード切り替え時にメモ再取得**
   - `handleEditToggle` を async 関数に変更
   - 編集モードに入る際、事前に `fetchOwnerMemo()` を await して完全なメモを取得
   - ISR直後の再取得完了を待つことで、マスク済みメモが編集フォームに表示されるのを防止

3. **null安全性の向上**
   - `setBook` の更新時に `prev ? { ...prev, memo: ... } : prev` で null チェック追加

4. **コメント改善**
   - ISRで生成されるメモがマスク済みである理由を明記
   - 所有者向けに元のメモ（[[MASK: ...]]アノテーション付き）を取得し直す必要性を説明

## 変更の種類

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## チェックリスト

- [ ] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

https://claude.ai/code/session_01JUg4p8LvUCXYynNKHriJ8u