### PR TITLE
Remove social share button from search success view

### DIFF
--- a/apps/web/src/components/input/SearchBox/SuccessView.tsx
+++ b/apps/web/src/components/input/SearchBox/SuccessView.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react'
 import { useReward } from 'react-rewards'
 import { motion } from 'framer-motion'
-import { FiShare2 } from 'react-icons/fi'
-import { shareToSns } from '@/utils/socialShare'
 
 interface SuccessViewProps {
   bookTitle: string
@@ -85,18 +83,6 @@ export const SuccessView: React.FC<SuccessViewProps> = ({
           className="w-full rounded-lg bg-blue-600 px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-blue-700"
         >
           「{sheetName}」を見る
-        </button>
-        <button
-          onClick={() =>
-            shareToSns(
-              `『${bookTitle}』を読書記録に追加しました📚 #kidoku`,
-              process.env.NEXT_PUBLIC_HOST || 'https://kidoku.net'
-            )
-          }
-          className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-6 py-3 text-sm font-bold text-gray-700 transition-colors hover:bg-gray-50"
-        >
-          <FiShare2 size={16} />
-          シェアする
         </button>
         <button
           onClick={onClose}


### PR DESCRIPTION
## 概要

検索成功画面（SuccessView）からソーシャルシェア機能を削除しました。シェアボタンと関連するインポート（`FiShare2`アイコン、`shareToSns`ユーティリティ）を削除しています。

## 変更の種類

- [x] Refactoring

## 詳細

以下の変更を実施しました：

- `apps/web/src/components/input/SearchBox/SuccessView.tsx` から不要なインポートを削除
  - `react-icons/fi` の `FiShare2` アイコン
  - `@/utils/socialShare` の `shareToSns` 関数
- SuccessView コンポーネントからシェアボタン（`<button>` 要素）を削除
  - ボタンのクリックハンドラーで `shareToSns()` を呼び出していた処理を削除

## チェックリスト

- [x] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した（該当なし）
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した（該当なし）
- [x] 必要に応じてテストを追加・更新した（UI削除のため不要）

https://claude.ai/code/session_01GPA4qLL1ABw7Zt9pac1Wy9