### PR TITLE
fix: 登録完了画面で変更後の本の画像を表示する

### DIFF
--- a/apps/web/src/components/input/SearchBox/RegisterForm.tsx
+++ b/apps/web/src/components/input/SearchBox/RegisterForm.tsx
@@ -47,6 +47,7 @@ interface Response {
   bookTitle: string
   bookId: number
   sheetName: string
+  bookImage: string
 }
 
 interface RegisterFormProps {

--- a/apps/web/src/components/input/SearchBox/SearchModal.tsx
+++ b/apps/web/src/components/input/SearchBox/SearchModal.tsx
@@ -107,10 +107,12 @@ export const SearchModal: React.FC = () => {
     bookTitle: string
     bookId: number
     sheetName: string
+    bookImage: string
   }) => {
     setSuccessData({
       bookTitle: response.bookTitle,
-      bookImage: selectedBook?.image || '',
+      // 登録APIが返す実際の保存画像を使う（フォームで変更した画像が反映される）
+      bookImage: response.bookImage || selectedBook?.image || '',
       sheetName: response.sheetName,
     })
     setView('success')

--- a/apps/web/src/pages/api/books/index.ts
+++ b/apps/web/src/pages/api/books/index.ts
@@ -49,7 +49,8 @@ export default async (req, res) => {
         isPublicMemo,
         finished: finished ? new Date(finished) : null,
       }
-      data['image'] = image === NO_IMAGE || image.includes('http') ? image : ''
+      let finalImage = image === NO_IMAGE || image.includes('http') ? image : ''
+      data['image'] = finalImage
       const book = await prisma.books.create({ data })
 
       // 画像選択された場合はVercel Blobにアップロードする
@@ -67,6 +68,7 @@ export default async (req, res) => {
             image: url,
           },
         })
+        finalImage = url
       }
       // ISRキャッシュを再検証
       try {
@@ -80,6 +82,7 @@ export default async (req, res) => {
         bookTitle: title,
         sheetName: sheet.name,
         bookId: book.id,
+        bookImage: finalImage,
       })
     } else if (req.method === 'PUT') {
       const body = JSON.parse(req.body)


### PR DESCRIPTION
本登録フォームで画像を変更しても、登録完了画面(SuccessView)には
検索結果の初期画像が表示されていた。

原因は SearchModal.handleSuccess が登録APIのレスポンスではなく
selectedBook?.image(選択時の画像)を使っていたため。POST /api/books
のレスポンスにも保存した画像が含まれていなかった。

- POST /api/books が実際に保存した画像(bookImage)を返すよう変更
- RegisterForm/SearchModal でそのレスポンス画像を SuccessView に渡す

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019vu6AZVPprdMWo7p74gEiE