### PR TITLE
feat: トータルページにカテゴリーフィルターを追加

### DIFF
--- a/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetTotal/SheetTotalPage.tsx
@@ -1,17 +1,20 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Category, Year } from '../../types'
 import { TitleWithLine } from '@/components/label/TitleWithLine'
 import { Rankings } from './Rankings'
 import { YearsGraph } from './YearsGraph'
 import { BasePieChart, PieSlice } from '../BasePieChart'
-import { YearlyTopBook } from '@/types/book'
+import { Books } from '../Books'
+import { Book, YearlyTopBook } from '@/types/book'
 import { Container } from '@/components/layout/Container'
 import { CoutUpText } from '@/components/label/CountUpText'
 import { SheetTabsWithMenu } from '../SheetTabsWithMenu'
 import { NextSeo } from 'next-seo'
+import { IoMdCloseCircle } from 'react-icons/io'
 
 interface Props {
   total: number
+  books: Book[]
   categories: Category[]
   years: Year[]
   sheets: Array<{ id: string; name: string; order: number }>
@@ -21,6 +24,7 @@ interface Props {
 }
 export const SheetTotalPage: React.FC<Props> = ({
   total,
+  books,
   categories,
   years,
   sheets,
@@ -37,6 +41,13 @@ export const SheetTotalPage: React.FC<Props> = ({
     }))
   }, [categories])
 
+  // カテゴリーフィルター。カテゴリーを選択するとその本だけを表示する
+  const [filter, setFilter] = useState('')
+  const filteredBooks = useMemo(
+    () => (filter ? books.filter((book) => book.category === filter) : []),
+    [filter, books]
+  )
+
   return (
     <Container>
       <NextSeo title={`${username}/Total | kidoku`} />
@@ -52,8 +63,26 @@ export const SheetTotalPage: React.FC<Props> = ({
         <CoutUpText value={total} unit="冊" />
 
         <div className="m-auto mb-4 h-[300px] w-full sm:h-[400px] sm:w-3/4">
-          <BasePieChart data={categoryData} outerRadius={120} stroke="none" />
+          <BasePieChart
+            data={categoryData}
+            outerRadius={120}
+            stroke="none"
+            onSelect={(name) => setFilter(name)}
+            onDeselect={() => setFilter('')}
+          />
         </div>
+
+        {filter && (
+          <div className="mb-12">
+            <div className="mb-6 flex items-center justify-center">
+              <div className="mr-2 text-2xl font-bold">{`「${filter}」の本`}</div>
+              <button onClick={() => setFilter('')}>
+                <IoMdCloseCircle size={20} />
+              </button>
+            </div>
+            <Books books={filteredBooks} bookId="" />
+          </div>
+        )}
 
         <TitleWithLine text="年間平均読書数" />
         <CoutUpText value={average} unit="冊" />

--- a/apps/web/src/pages/[user]/sheets/total.tsx
+++ b/apps/web/src/pages/[user]/sheets/total.tsx
@@ -1,7 +1,8 @@
 import { SheetTotalPage } from '@/features/sheet/components/SheetTotal/SheetTotalPage'
 import { Category, Year } from '@/features/sheet/types'
-import prisma from '@/libs/prisma'
+import prisma, { parse } from '@/libs/prisma'
 import { mask } from '@/utils/string'
+import dayjs from 'dayjs'
 
 export default SheetTotalPage
 
@@ -19,6 +20,31 @@ export const getStaticProps = async (ctx) => {
   const books = await prisma.books.findMany({
     where: { userId },
   })
+  // 全シート横断の書籍データ（カテゴリーフィルター表示用）
+  // 公開ページのため、非公開メモは表示しない（[year].tsx と同様の整形）
+  const booksData = parse(
+    books.map((book) => {
+      const month = book.finished
+        ? dayjs(book.finished).format('M') + '月'
+        : dayjs().format('M') + '月'
+      return {
+        id: book.id,
+        userId: book.userId,
+        month,
+        title: book.title,
+        author: book.author,
+        category: book.category,
+        image: book.image,
+        impression: book.impression,
+        memo: book.isPublicMemo ? mask(book.memo) : '',
+        finished: book.finished,
+        isPublicMemo: book.isPublicMemo,
+        isPurchasable: book.isPurchasable,
+        price: book.price,
+        sheetId: book.sheetId,
+      }
+    })
+  )
   // データの整形。カテゴリ名をKey, 冊数をValueとしたオブジェクトを生成
   const category_count: Record<string, number> = {}
   books.forEach((book) => {
@@ -78,6 +104,7 @@ export const getStaticProps = async (ctx) => {
   return {
     props: {
       total: books.length,
+      books: booksData,
       categories,
       years,
       sheets:


### PR DESCRIPTION
トータルページのカテゴリー円グラフをクリックできるようにし、選択した
カテゴリーの本だけを一覧表示する。通常のシートページと同様のUXで、
ラベルと解除ボタンを表示する。

- total.tsx: 全シート横断の書籍データをpropsで渡す（公開ページのため
  非公開メモはマスク）
- SheetTotalPage.tsx: BasePieChartのonSelect/onDeselectでフィルター
  状態を管理し、Booksコンポーネントで該当書籍を表示

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kexh8ntqZieGsbmxUeUv3n