### PR TITLE
fix: db-pushワークフローのブランチ指定をテキスト入力から実行時選択に変更

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -11,11 +11,6 @@ on:
         options:
           - Production
           - Preview
-      branch:
-        description: 'スキーマを取得するブランチ（空欄ならワークフロー実行時に選択したブランチ）'
-        required: false
-        default: ''
-        type: string
       accept_data_loss:
         description: 'データ損失を許容して push する（--accept-data-loss）'
         required: false
@@ -32,10 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      # スキーマの取得元は実行時に「Use workflow from」で選択したブランチ
       - uses: actions/checkout@v4
-        with:
-          # branch が指定されていればそのブランチを、空欄なら実行時に選択したブランチを使う
-          ref: ${{ inputs.branch || github.ref }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
workflow_dispatchのbranchテキスト入力を廃止し、実行時の
「Use workflow from」ブランチセレクタで選択する方式に統一する。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q7NMMKDyL8QpBo7kkpYucm