### PR TITLE
ci: Prismaスキーマ変更時にdb pushを自動実行するようワークフローを拡張

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -1,6 +1,23 @@
 name: DB Push
 
 on:
+  # main/master へのプッシュでスキーマが変更されたら Production DB に自動反映
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'apps/web/prisma/schema.prisma'
+      - 'apps/api/prisma/schema.prisma'
+  # PR でスキーマが変更されたら Preview DB に自動反映
+  # （フォークからの PR は Secrets にアクセスできないため対象外）
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'apps/web/prisma/schema.prisma'
+      - 'apps/api/prisma/schema.prisma'
   workflow_dispatch:
     inputs:
       environment:
@@ -17,18 +34,28 @@ on:
         default: false
         type: boolean
 
-# 同時に複数の db push が走らないように直列化する
+# 同一環境への db push が同時に走らないように直列化する
 concurrency:
-  group: db-push
+  group: db-push-${{ github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'pull_request' && 'Preview' || 'Production' }}
   cancel-in-progress: false
 
 jobs:
   db-push:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    # push(main/master) → Production / pull_request → Preview / 手動実行 → 選択した環境
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || github.event_name == 'pull_request' && 'Preview' || 'Production' }}
     steps:
-      # スキーマの取得元は実行時に「Use workflow from」で選択したブランチ
+      # 自動実行時はトリガーとなったコミット、手動実行時は「Use workflow from」で選択したブランチのスキーマを使う
       - uses: actions/checkout@v4
+
+      # web と api の Prisma スキーマが同期しているか確認（片方だけの変更を検出）
+      - name: Check schema sync
+        run: |
+          if ! diff -u apps/web/prisma/schema.prisma apps/api/prisma/schema.prisma; then
+            echo "::error::apps/web/prisma/schema.prisma と apps/api/prisma/schema.prisma が一致していません。両方のスキーマを同期してください。"
+            exit 1
+          fi
+
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ pnpm --filter web lighthouse
 
 - プレビュー用APIは全PR共通の単一サービス `kidoku-api-preview` にデプロイされ、最新のデプロイで上書きされる
 - プレビュー用の Secrets（`DATABASE_URL`, `NEXTAUTH_SECRET`, `FRONTEND_URL` 等）は GitHub の `Preview` Environment に登録する
-- プレビューDBへのスキーマ反映は `db-push.yml` を `Preview` 環境指定で手動実行する
+- DBへのスキーマ反映は `db-push.yml` が自動実行する: Prismaスキーマ変更を含む main/master へのpushで本番DB（`Production`）へ、PR（main/master 宛て）でプレビューDB（`Preview`）へ `prisma db push` が走る。`workflow_dispatch` での手動実行（環境選択・`--accept-data-loss` 指定）も引き続き可能
 - フォークからのPRはSecretsにアクセスできないため、プレビューデプロイは同一リポジトリ内のブランチPRでのみ動作する
 
 ## サンドボックス環境での開発


### PR DESCRIPTION
- main/masterへのpush（スキーマ変更時）でProduction DBへ自動反映
- PR（main/master宛て、スキーマ変更時）でPreview DBへ自動反映
- workflow_dispatchによる手動実行は従来どおり維持
- web/api両Prismaスキーマの同期チェックを追加
- concurrencyグループを環境ごとに分離

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BMfZtH6qJwDzp8SDvYMSxj