### PR TITLE
Add pagination support to /api/v1/books endpoint

### DIFF
--- a/apps/web/src/features/settings/ApiTokensPage.tsx
+++ b/apps/web/src/features/settings/ApiTokensPage.tsx
@@ -178,8 +178,11 @@ export const ApiTokensPage: React.FC = () => {
           発行したトークンをAuthorizationヘッダーに指定して読書記録を取得できます。
         </p>
         <pre className="overflow-x-auto rounded bg-slate-900 p-4 font-mono text-xs text-slate-100">
-          {`curl -H "Authorization: Bearer <トークン>" \\\n  ${typeof window !== 'undefined' ? window.location.origin : 'https://kidoku.net'}/api/v1/books`}
+          {`curl -H "Authorization: Bearer <トークン>" \\\n  "${typeof window !== 'undefined' ? window.location.origin : 'https://kidoku.net'}/api/v1/books?page=1&perPage=100"`}
         </pre>
+        <p className="mt-2 text-xs text-gray-500">
+          読了日の新しい順に返されます。page（ページ番号、1始まり）とperPage（1ページあたりの件数、デフォルト100・最大200）でページネーションできます。
+        </p>
       </section>
     </Container>
   )

--- a/apps/web/src/pages/api/v1/books.test.ts
+++ b/apps/web/src/pages/api/v1/books.test.ts
@@ -1,0 +1,137 @@
+import { createHash } from 'crypto'
+import { NextApiRequest, NextApiResponse } from 'next'
+import handler from './books'
+
+jest.mock('@/libs/prisma', () => ({
+  __esModule: true,
+  default: {
+    personalAccessToken: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    books: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}))
+
+const prisma = jest.requireMock('@/libs/prisma').default
+
+const TOKEN = 'kidoku_pat_test'
+const TOKEN_HASH = createHash('sha256').update(TOKEN).digest('hex')
+
+const mockReq = (query: Record<string, string> = {}, token = TOKEN) =>
+  ({
+    method: 'GET',
+    headers: { authorization: `Bearer ${token}` },
+    query,
+  }) as unknown as NextApiRequest
+
+const mockRes = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+  }
+  res.status.mockReturnValue(res)
+  return res as unknown as NextApiResponse & typeof res
+}
+
+const mockBook = (id: number) => ({
+  id,
+  title: `本${id}`,
+  author: '著者',
+  category: '技術書',
+  impression: '◎',
+  memo: 'メモ',
+  sheet: { name: '2026' },
+  finished: new Date('2026-01-15T00:00:00Z'),
+  created: new Date('2026-01-01T00:00:00Z'),
+  updated: new Date('2026-01-02T00:00:00Z'),
+})
+
+describe('/api/v1/books', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prisma.personalAccessToken.findUnique.mockResolvedValue({
+      id: 1,
+      userId: 'user-1',
+    })
+    prisma.personalAccessToken.update.mockResolvedValue({})
+    prisma.$transaction.mockResolvedValue([250, [mockBook(1), mockBook(2)]])
+  })
+
+  it('デフォルトでpage=1, perPage=100で取得しメタ情報を返す', async () => {
+    const res = mockRes()
+    await handler(mockReq(), res)
+
+    expect(prisma.books.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0, take: 100 })
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        total: 250,
+        page: 1,
+        perPage: 100,
+        totalPages: 3,
+      })
+    )
+    const body = res.json.mock.calls[0][0]
+    expect(body.books).toHaveLength(2)
+    expect(body.books[0]).toEqual({
+      id: 1,
+      title: '本1',
+      author: '著者',
+      category: '技術書',
+      impression: '◎',
+      memo: 'メモ',
+      sheet: '2026',
+      finished: '2026-01-15T00:00:00.000Z',
+      created: '2026-01-01T00:00:00.000Z',
+      updated: '2026-01-02T00:00:00.000Z',
+    })
+  })
+
+  it('page/perPage指定でskip/takeが計算される', async () => {
+    const res = mockRes()
+    await handler(mockReq({ page: '3', perPage: '50' }), res)
+
+    expect(prisma.books.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 100, take: 50 })
+    )
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 3, perPage: 50, totalPages: 5 })
+    )
+  })
+
+  it('perPageは最大200に切り詰められる', async () => {
+    const res = mockRes()
+    await handler(mockReq({ perPage: '9999' }), res)
+
+    expect(prisma.books.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 200 })
+    )
+  })
+
+  it('不正なpageは400を返す', async () => {
+    const res = mockRes()
+    await handler(mockReq({ page: 'abc' }), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(prisma.books.findMany).not.toHaveBeenCalled()
+  })
+
+  it('無効なトークンは401を返す', async () => {
+    prisma.personalAccessToken.findUnique.mockResolvedValue(null)
+    const res = mockRes()
+    await handler(mockReq(), res)
+
+    expect(prisma.personalAccessToken.findUnique).toHaveBeenCalledWith({
+      where: { tokenHash: TOKEN_HASH },
+    })
+    expect(res.status).toHaveBeenCalledWith(401)
+  })
+})

--- a/apps/web/src/pages/api/v1/books.ts
+++ b/apps/web/src/pages/api/v1/books.ts
@@ -1,11 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { createHash } from 'crypto'
 import prisma from '@/libs/prisma'
+import { parsePagination } from '@/utils/pagination'
 
 // 個人用REST API v1: 自分の読書記録を取得する（読み取り専用）
 //
 // 認証: パーソナルアクセストークン（設定 > 個人用API で発行）
 //   curl -H "Authorization: Bearer kidoku_pat_xxx" https://kidoku.net/api/v1/books
+//
+// クエリパラメータ:
+//   page:    ページ番号（1始まり、デフォルト1）
+//   perPage: 1ページあたりの件数（デフォルト100、最大200）
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -23,6 +28,12 @@ export default async function handler(
   const token = auth.slice('Bearer '.length).trim()
   const tokenHash = createHash('sha256').update(token).digest('hex')
 
+  const pagination = parsePagination(req.query)
+  if ('error' in pagination) {
+    return res.status(400).json({ error: pagination.error })
+  }
+  const { page, perPage } = pagination
+
   try {
     const pat = await prisma.personalAccessToken.findUnique({
       where: { tokenHash },
@@ -36,31 +47,36 @@ export default async function handler(
       data: { lastUsedAt: new Date() },
     })
 
-    const sheets = await prisma.sheets.findMany({
-      where: { userId: pat.userId },
-      include: {
-        books: {
-          orderBy: { finished: 'desc' },
-        },
-      },
-      orderBy: { order: 'asc' },
-    })
+    const where = { userId: pat.userId }
+    const [total, books] = await prisma.$transaction([
+      prisma.books.count({ where }),
+      prisma.books.findMany({
+        where,
+        include: { sheet: { select: { name: true } } },
+        // MySQLではDESCでNULL(未読了)が末尾に並ぶ。idは同日読了時の順序安定用
+        orderBy: [{ finished: 'desc' }, { id: 'desc' }],
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+    ])
 
     res.setHeader('Cache-Control', 'private, no-store')
     return res.status(200).json({
-      sheets: sheets.map((sheet) => ({
-        name: sheet.name,
-        books: sheet.books.map((book) => ({
-          id: book.id,
-          title: book.title,
-          author: book.author,
-          category: book.category,
-          impression: book.impression,
-          memo: book.memo,
-          finished: book.finished?.toISOString() ?? null,
-          created: book.created.toISOString(),
-          updated: book.updated.toISOString(),
-        })),
+      total,
+      page,
+      perPage,
+      totalPages: Math.ceil(total / perPage),
+      books: books.map((book) => ({
+        id: book.id,
+        title: book.title,
+        author: book.author,
+        category: book.category,
+        impression: book.impression,
+        memo: book.memo,
+        sheet: book.sheet.name,
+        finished: book.finished?.toISOString() ?? null,
+        created: book.created.toISOString(),
+        updated: book.updated.toISOString(),
       })),
     })
   } catch (error) {

--- a/apps/web/src/utils/pagination.test.ts
+++ b/apps/web/src/utils/pagination.test.ts
@@ -1,0 +1,53 @@
+import { parsePagination, DEFAULT_PER_PAGE, MAX_PER_PAGE } from './pagination'
+
+describe('parsePagination', () => {
+  it('パラメータ未指定ならデフォルト値を返す', () => {
+    expect(parsePagination({})).toEqual({
+      page: 1,
+      perPage: DEFAULT_PER_PAGE,
+    })
+  })
+
+  it('指定されたpage/perPageを返す', () => {
+    expect(parsePagination({ page: '3', perPage: '50' })).toEqual({
+      page: 3,
+      perPage: 50,
+    })
+  })
+
+  it('perPageが上限を超える場合は上限に切り詰める', () => {
+    expect(parsePagination({ perPage: '1000' })).toEqual({
+      page: 1,
+      perPage: MAX_PER_PAGE,
+    })
+  })
+
+  it('配列で渡された場合は先頭の値を使う', () => {
+    expect(parsePagination({ page: ['2', '5'] })).toEqual({
+      page: 2,
+      perPage: DEFAULT_PER_PAGE,
+    })
+  })
+
+  it.each([
+    ['0', 'ゼロ'],
+    ['-1', '負数'],
+    ['abc', '数値以外'],
+    ['1.5', '小数'],
+    ['', '空文字'],
+  ])('pageが不正な値(%s: %s)ならエラーを返す', (value) => {
+    expect(parsePagination({ page: value })).toEqual({
+      error: 'pageは1以上の整数で指定してください',
+    })
+  })
+
+  it.each([
+    ['0', 'ゼロ'],
+    ['-1', '負数'],
+    ['abc', '数値以外'],
+  ])('perPageが不正な値(%s: %s)ならエラーを返す', (value) => {
+    expect(parsePagination({ perPage: value })).toEqual({
+      error: 'perPageは1以上の整数で指定してください',
+    })
+  })
+})

--- a/apps/web/src/utils/pagination.ts
+++ b/apps/web/src/utils/pagination.ts
@@ -1,0 +1,34 @@
+export const DEFAULT_PER_PAGE = 100
+export const MAX_PER_PAGE = 200
+
+export type Pagination = { page: number; perPage: number }
+export type PaginationError = { error: string }
+
+const parsePositiveInt = (
+  value: string | string[] | undefined,
+  defaultValue: number
+): number | null => {
+  if (value === undefined) return defaultValue
+  const raw = Array.isArray(value) ? value[0] : value
+  if (!/^\d+$/.test(raw)) return null
+  const parsed = parseInt(raw, 10)
+  if (parsed < 1) return null
+  return parsed
+}
+
+// クエリパラメータからページネーション情報を取り出す。
+// page: 1始まり（デフォルト1）、perPage: デフォルト100・最大200（超過分は切り詰め）
+export const parsePagination = (query: {
+  page?: string | string[]
+  perPage?: string | string[]
+}): Pagination | PaginationError => {
+  const page = parsePositiveInt(query.page, 1)
+  if (page === null) {
+    return { error: 'pageは1以上の整数で指定してください' }
+  }
+  const perPage = parsePositiveInt(query.perPage, DEFAULT_PER_PAGE)
+  if (perPage === null) {
+    return { error: 'perPageは1以上の整数で指定してください' }
+  }
+  return { page, perPage: Math.min(perPage, MAX_PER_PAGE) }
+}


### PR DESCRIPTION
## 概要

REST API v1の `/api/v1/books` エンドポイントにページネーション機能を追加しました。

### 変更内容

1. **ページネーション機能の実装**
   - `parsePagination()` ユーティリティ関数を新規作成（`apps/web/src/utils/pagination.ts`）
   - クエリパラメータ `page`（1始まり、デフォルト1）と `perPage`（デフォルト100、最大200）をサポート
   - 不正な値に対するバリデーション機能

2. **APIエンドポイントの改善**
   - `/api/v1/books` をページネーション対応に変更
   - 従来のシート単位の構造から、全書籍を読了日の新しい順に返すように変更
   - レスポンスに `total`、`page`、`perPage`、`totalPages` のメタ情報を追加
   - Prismaトランザクションで総件数と該当ページのデータを効率的に取得

3. **ドキュメント更新**
   - APIドキュメント（コメント）にクエリパラメータの説明を追加
   - 設定ページのAPI使用例を更新（ページネーションパラメータを含める）

### レスポンス形式の変更

**変更前:**
```json
{
  "sheets": [
    {
      "name": "2026",
      "books": [...]
    }
  ]
}
```

**変更後:**
```json
{
  "total": 250,
  "page": 1,
  "perPage": 100,
  "totalPages": 3,
  "books": [...]
}
```

## 変更の種類

- [x] New feature
- [x] Refactoring

## チェックリスト

- [x] `pnpm validate` が通ること
- [x] 必要に応じてテストを追加・更新した
  - `apps/web/src/utils/pagination.test.ts` - ページネーション解析ロジックの単体テスト（53行）
  - `apps/web/src/pages/api/v1/books.test.ts` - APIエンドポイントの統合テスト（137行）
  - デフォルト値、パラメータ指定、上限値、バリデーション、認証エラーなど全シナリオをカバー

https://claude.ai/code/session_01TTYRydkruhiP4D7xSJwfFP