### PR TITLE
feat: AI分析にMBTI風の読書性格タイプ診断（キャラクター画像付き）を追加

### DIFF
--- a/apps/api/src/application/usecases/ai-summaries/save-ai-summary.spec.ts
+++ b/apps/api/src/application/usecases/ai-summaries/save-ai-summary.spec.ts
@@ -57,7 +57,34 @@ describe('SaveAiSummaryUseCase', () => {
     expect(mockAiSummaryRepo.create).toHaveBeenCalledWith(
       'user-1',
       1,
-      { _schemaVersion: 2, ...validAnalysis },
+      { _schemaVersion: 3, personality_type: '', ...validAnalysis },
+      0,
+    );
+  });
+
+  it('読書性格タイプ付きの分析データを保存できる', async () => {
+    const sheet = Sheet.fromDatabase(
+      '1',
+      'user-1',
+      '2025',
+      1,
+      new Date(),
+      new Date(),
+    );
+    mockSheetRepo.findByUserIdAndName.mockResolvedValue(sheet);
+    mockAiSummaryRepo.create.mockResolvedValue(undefined);
+
+    const analysisWithType = {
+      ...validAnalysis,
+      personality_type: 'adventurer',
+    };
+
+    await useCase.execute('user-1', '2025', analysisWithType);
+
+    expect(mockAiSummaryRepo.create).toHaveBeenCalledWith(
+      'user-1',
+      1,
+      { _schemaVersion: 3, ...analysisWithType },
       0,
     );
   });

--- a/apps/api/src/application/usecases/ai-summaries/save-ai-summary.ts
+++ b/apps/api/src/application/usecases/ai-summaries/save-ai-summary.ts
@@ -38,7 +38,9 @@ export class SaveAiSummaryUseCase {
       userId,
       parseInt(sheet.id, 10),
       {
-        _schemaVersion: 2,
+        _schemaVersion: 3,
+        // 読書性格タイプは旧フォーマットのペーストでも保存できるよう任意とする
+        personality_type: '',
         ...analysis,
       },
       0,

--- a/apps/web/src/features/sheet/components/AiSummaries/AiSummaries.tsx
+++ b/apps/web/src/features/sheet/components/AiSummaries/AiSummaries.tsx
@@ -7,6 +7,8 @@ import useAiHelpers from './useAiHelpers'
 import { Confirm } from './Confirm'
 import { StepIndicator } from './StepIndicator'
 import { AI_SUMMARY_FIELDS, AiSummaryFieldKey } from './fields'
+import { PersonalityCard } from './personality/PersonalityCard'
+import { findPersonalityType } from '@/libs/ai/personality/personality-types'
 import { CourseId } from '@/types/user'
 import { Book } from '@/types/book'
 import { FaCircleNotch, FaTrash } from 'react-icons/fa'
@@ -43,6 +45,9 @@ export const AiSummaries: React.FC<Props> = ({
     summaryIndex,
     setSummaryIndex,
   } = useAiHelpers(sheet, aiSummaries)
+
+  // MBTI風の読書性格タイプ（未診断の過去データ・不明IDはundefined）
+  const personalityType = findPersonalityType(json?.personality_type)
 
   if (error) {
     return <Error text={error} />
@@ -108,31 +113,49 @@ export const AiSummaries: React.FC<Props> = ({
               <span>削除</span>
             </button>
           )}
-          {json.character_summary && (
-            <div className="mb-6 rounded-lg bg-gradient-to-r from-purple-50 to-pink-50 px-6 py-5 shadow-sm">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
-                一言でいうとこんな人
-              </h3>
-              <p className="text-xl font-bold leading-relaxed text-gray-800">
-                {json.character_summary}
-              </p>
-              {isMine && (
-                <div className="mt-4 flex justify-center">
-                  <button
-                    onClick={() =>
-                      shareToSns(
-                        `私の読書性格は「${json.character_summary}」でした📚✨\n#kidoku のAI読書分析`,
-                        shareUrl
-                      )
-                    }
-                    className="flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 px-5 py-2 text-sm font-bold text-white shadow-sm transition-transform hover:scale-105 hover:brightness-105"
-                  >
-                    <FiShare2 size={16} />
-                    診断結果をシェア
-                  </button>
-                </div>
-              )}
-            </div>
+          {personalityType ? (
+            <PersonalityCard
+              type={personalityType}
+              characterSummary={json.character_summary}
+              showShare={isMine}
+              onShare={() =>
+                shareToSns(
+                  `私の読書性格タイプは「${personalityType.name}」でした📚✨\n${
+                    json.character_summary
+                      ? `一言でいうと「${json.character_summary}」\n`
+                      : ''
+                  }#kidoku のAI読書分析`,
+                  shareUrl
+                )
+              }
+            />
+          ) : (
+            json.character_summary && (
+              <div className="mb-6 rounded-lg bg-gradient-to-r from-purple-50 to-pink-50 px-6 py-5 shadow-sm">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  一言でいうとこんな人
+                </h3>
+                <p className="text-xl font-bold leading-relaxed text-gray-800">
+                  {json.character_summary}
+                </p>
+                {isMine && (
+                  <div className="mt-4 flex justify-center">
+                    <button
+                      onClick={() =>
+                        shareToSns(
+                          `私の読書性格は「${json.character_summary}」でした📚✨\n#kidoku のAI読書分析`,
+                          shareUrl
+                        )
+                      }
+                      className="flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 px-5 py-2 text-sm font-bold text-white shadow-sm transition-transform hover:scale-105 hover:brightness-105"
+                    >
+                      <FiShare2 size={16} />
+                      診断結果をシェア
+                    </button>
+                  </div>
+                )}
+              </div>
+            )
           )}
           <div className="mb-1 grid grid-cols-1 gap-4 md:grid-cols-2">
             {Object.keys(json)
@@ -140,6 +163,7 @@ export const AiSummaries: React.FC<Props> = ({
                 (key) =>
                   key !== 'id' &&
                   key !== 'character_summary' &&
+                  key !== 'personality_type' &&
                   !key.startsWith('_')
               )
               .sort((a, b) => {

--- a/apps/web/src/features/sheet/components/AiSummaries/migrations.ts
+++ b/apps/web/src/features/sheet/components/AiSummaries/migrations.ts
@@ -59,12 +59,12 @@ export const MIGRATIONS: Migration[] = [
       },
     ],
   },
-  // 将来的なマイグレーション例：
-  // {
-  //   from: 2,
-  //   to: 3,
-  //   transformations: [
-  //     { type: 'add', key: 'reading_motivation', defaultValue: '' },
-  //   ]
-  // }
+  {
+    from: 2,
+    to: 3,
+    transformations: [
+      // 読書性格タイプ（MBTI風診断）。過去データは未診断のため空文字
+      { type: 'add', key: 'personality_type', defaultValue: '' },
+    ],
+  },
 ]

--- a/apps/web/src/features/sheet/components/AiSummaries/migrator.test.ts
+++ b/apps/web/src/features/sheet/components/AiSummaries/migrator.test.ts
@@ -1,8 +1,8 @@
 import { migrateAnalysis } from './migrator'
 
 describe('migrateAnalysis()', () => {
-  describe('バージョン1からバージョン2へのマイグレーション', () => {
-    it('what_if_scenarioがhidden_theme_discoveryにリネームされること', () => {
+  describe('バージョン1から最新バージョンへのマイグレーション', () => {
+    it('what_if_scenarioがhidden_theme_discoveryにリネームされ、personality_typeが追加されること', () => {
       const v1Data = {
         character_summary: 'テスト人物像',
         reading_trend_analysis: 'テスト傾向',
@@ -14,8 +14,9 @@ describe('migrateAnalysis()', () => {
       const result = migrateAnalysis(v1Data)
 
       expect(result).toEqual({
-        _schemaVersion: 2,
+        _schemaVersion: 3,
         _originalSchemaVersion: 1,
+        personality_type: '',
         character_summary: 'テスト人物像',
         reading_trend_analysis: 'テスト傾向',
         sentiment_analysis: 'テスト感情',
@@ -51,15 +52,16 @@ describe('migrateAnalysis()', () => {
 
       const result = migrateAnalysis(v1Data)
 
-      expect(result._schemaVersion).toBe(2)
+      expect(result._schemaVersion).toBe(3)
       expect(result._originalSchemaVersion).toBe(1)
       expect(result.hidden_theme_discovery).toBe('テストシナリオ')
+      expect(result.personality_type).toBe('')
       expect(result).not.toHaveProperty('what_if_scenario')
     })
   })
 
-  describe('すでに最新バージョンの場合', () => {
-    it('_schemaVersionが2の場合は変換されずそのまま返ること', () => {
+  describe('バージョン2からバージョン3へのマイグレーション', () => {
+    it('personality_typeが空文字で追加されること', () => {
       const v2Data = {
         _schemaVersion: 2,
         character_summary: 'テスト人物像',
@@ -71,12 +73,18 @@ describe('migrateAnalysis()', () => {
 
       const result = migrateAnalysis(v2Data)
 
-      expect(result).toEqual(v2Data)
-      expect(result._originalSchemaVersion).toBeUndefined()
+      expect(result._schemaVersion).toBe(3)
+      expect(result._originalSchemaVersion).toBe(2)
+      expect(result.personality_type).toBe('')
+      expect(result.hidden_theme_discovery).toBe('テストテーマ')
     })
+  })
 
-    it('すでにhidden_theme_discoveryを持つデータはそのまま返ること', () => {
-      const v2Data = {
+  describe('すでに最新バージョンの場合', () => {
+    it('_schemaVersionが3の場合は変換されずそのまま返ること', () => {
+      const v3Data = {
+        _schemaVersion: 3,
+        personality_type: 'adventurer',
         character_summary: 'テスト人物像',
         reading_trend_analysis: 'テスト傾向',
         sentiment_analysis: 'テスト感情',
@@ -84,9 +92,27 @@ describe('migrateAnalysis()', () => {
         overall_feedback: 'テスト総評',
       }
 
-      const result = migrateAnalysis(v2Data)
+      const result = migrateAnalysis(v3Data)
 
-      expect(result.hidden_theme_discovery).toBe('テストテーマ')
+      expect(result).toEqual(v3Data)
+      expect(result._originalSchemaVersion).toBeUndefined()
+    })
+
+    it('すでにpersonality_typeを持つデータは上書きされないこと', () => {
+      const v2DataWithType = {
+        _schemaVersion: 2,
+        personality_type: 'detective',
+        character_summary: 'テスト人物像',
+        reading_trend_analysis: 'テスト傾向',
+        sentiment_analysis: 'テスト感情',
+        hidden_theme_discovery: 'テストテーマ',
+        overall_feedback: 'テスト総評',
+      }
+
+      const result = migrateAnalysis(v2DataWithType)
+
+      expect(result._schemaVersion).toBe(3)
+      expect(result.personality_type).toBe('detective')
     })
   })
 
@@ -105,6 +131,7 @@ describe('migrateAnalysis()', () => {
       const result = migrateAnalysis(partialData)
 
       expect(result.hidden_theme_discovery).toBe('テストシナリオのみ')
+      expect(result.personality_type).toBe('')
       expect(result).not.toHaveProperty('what_if_scenario')
     })
   })

--- a/apps/web/src/features/sheet/components/AiSummaries/personality/PersonalityCard.tsx
+++ b/apps/web/src/features/sheet/components/AiSummaries/personality/PersonalityCard.tsx
@@ -1,0 +1,74 @@
+import { FiShare2 } from 'react-icons/fi'
+import type { PersonalityType } from '@/libs/ai/personality/personality-types'
+import { personalityCharacterDataUri } from '@/libs/ai/personality/personality-character'
+
+interface Props {
+  type: PersonalityType
+  characterSummary: string
+  showShare: boolean
+  onShare: () => void
+}
+
+/**
+ * MBTI診断風の読書性格タイプカード
+ * キャラクター画像・タイプコード・タイプ名を診断結果のヒーローとして表示する
+ */
+export const PersonalityCard: React.FC<Props> = ({
+  type,
+  characterSummary,
+  showShare,
+  onShare,
+}) => {
+  return (
+    <div
+      className="mb-6 rounded-xl px-6 py-7 shadow-sm"
+      style={{
+        background: `linear-gradient(135deg, ${type.colorLight} 0%, #ffffff 60%, ${type.colorLight}80 100%)`,
+      }}
+    >
+      <h3 className="mb-4 text-xs font-semibold uppercase tracking-wide text-gray-500">
+        あなたの読書性格タイプ
+      </h3>
+      <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center sm:gap-8">
+        <img
+          src={personalityCharacterDataUri(type)}
+          alt={type.name}
+          width={140}
+          height={140}
+          className="h-[140px] w-[140px] drop-shadow-md"
+        />
+        <div className="text-center sm:text-left">
+          <span
+            className="inline-block rounded-full px-3 py-1 text-xs font-bold tracking-widest text-white"
+            style={{ backgroundColor: type.color }}
+          >
+            {type.code}
+          </span>
+          <p
+            className="mt-2 text-2xl font-extrabold leading-snug"
+            style={{ color: type.color }}
+          >
+            {type.name}
+          </p>
+          <p className="mt-1 text-sm text-gray-500">{type.tagline}</p>
+        </div>
+      </div>
+      {characterSummary && (
+        <p className="mt-5 text-lg font-bold leading-relaxed text-gray-800">
+          「{characterSummary}」
+        </p>
+      )}
+      {showShare && (
+        <div className="mt-5 flex justify-center">
+          <button
+            onClick={onShare}
+            className="flex items-center gap-2 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 px-5 py-2 text-sm font-bold text-white shadow-sm transition-transform hover:scale-105 hover:brightness-105"
+          >
+            <FiShare2 size={16} />
+            診断結果をシェア
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/sheet/components/AiSummaries/schema.ts
+++ b/apps/web/src/features/sheet/components/AiSummaries/schema.ts
@@ -9,7 +9,7 @@
 /**
  * 現在の最新スキーマバージョン
  */
-export const AI_SUMMARY_SCHEMA_VERSION = 2
+export const AI_SUMMARY_SCHEMA_VERSION = 3
 
 /**
  * スキーマバージョンごとのフィールド定義
@@ -28,6 +28,17 @@ export const AI_SUMMARY_SCHEMAS = {
   2: {
     version: 2,
     fields: [
+      'character_summary',
+      'reading_trend_analysis',
+      'sentiment_analysis',
+      'hidden_theme_discovery',
+      'overall_feedback',
+    ] as const,
+  },
+  3: {
+    version: 3,
+    fields: [
+      'personality_type',
       'character_summary',
       'reading_trend_analysis',
       'sentiment_analysis',

--- a/apps/web/src/features/sheet/components/AiSummaries/types.ts
+++ b/apps/web/src/features/sheet/components/AiSummaries/types.ts
@@ -8,6 +8,8 @@ export type AiSummariesJson = {
   _schemaVersion?: number
   /** 元のスキーマバージョン（レガシー表示用） */
   _originalSchemaVersion?: number
+  /** 読書性格タイプのID（personality-types.tsで定義、未診断の過去データは空文字） */
+  personality_type: string
   /** 一言でいうとこんな人 */
   character_summary: string
   /** 読書傾向分析 */

--- a/apps/web/src/features/sheet/components/SheetPage.tsx
+++ b/apps/web/src/features/sheet/components/SheetPage.tsx
@@ -187,7 +187,9 @@ export const SheetPage: React.FC<Props> = ({
         username
       )}&summary=${encodeURIComponent(
         latestAiSummary.character_summary
-      )}&sub=${encodeURIComponent(latestAiSummary.overall_feedback ?? '')}`
+      )}&sub=${encodeURIComponent(
+        latestAiSummary.overall_feedback ?? ''
+      )}&ptype=${encodeURIComponent(latestAiSummary.personality_type ?? '')}`
     : ''
   // AI診断があればそれを、なければ年間まとめ（Wrapped）をOGに使う
   const ogImage = latestAiSummary ? aiOgImage : wrappedOgImage

--- a/apps/web/src/libs/ai/personality/personality-character.ts
+++ b/apps/web/src/libs/ai/personality/personality-character.ts
@@ -1,0 +1,120 @@
+import type { PersonalityFace, PersonalityType } from './personality-types'
+
+/**
+ * 読書性格タイプのキャラクター画像（SVG）を生成する
+ *
+ * Web UIとOG画像（@vercel/og）の両方で使うため、SVG文字列として単一ソースで管理する。
+ * OG画像側でbase64エンコードするため、SVG内はASCII文字のみで構成すること（<text>要素は使わない）。
+ */
+
+const face = (type: PersonalityType): string => {
+  const eyesByFace: Record<PersonalityFace, string> = {
+    round: `
+      <circle cx="98" cy="118" r="7" fill="#1f2937"/>
+      <circle cx="142" cy="118" r="7" fill="#1f2937"/>
+      <circle cx="100.5" cy="115.5" r="2.5" fill="#ffffff"/>
+      <circle cx="144.5" cy="115.5" r="2.5" fill="#ffffff"/>`,
+    closed: `
+      <path d="M91 118 q7 7 14 0" stroke="#1f2937" stroke-width="3.5" stroke-linecap="round" fill="none"/>
+      <path d="M135 118 q7 7 14 0" stroke="#1f2937" stroke-width="3.5" stroke-linecap="round" fill="none"/>`,
+    sparkle: `
+      <path d="M98 109 l2.6 6 6 2.6 -6 2.6 -2.6 6 -2.6 -6 -6 -2.6 6 -2.6 Z" fill="#1f2937"/>
+      <path d="M142 109 l2.6 6 6 2.6 -6 2.6 -2.6 6 -2.6 -6 -6 -2.6 6 -2.6 Z" fill="#1f2937"/>`,
+  }
+
+  return `${eyesByFace[type.face]}
+      <ellipse cx="84" cy="132" rx="7.5" ry="4.5" fill="#fda4af" opacity="0.7"/>
+      <ellipse cx="156" cy="132" rx="7.5" ry="4.5" fill="#fda4af" opacity="0.7"/>
+      <path d="M112 136 q8 8 16 0" stroke="#1f2937" stroke-width="3.5" stroke-linecap="round" fill="none"/>`
+}
+
+const accessories: Record<string, string> = {
+  adventurer: `
+      <ellipse cx="120" cy="86" rx="47" ry="10" fill="#92400e"/>
+      <path d="M94 86 Q94 56 120 56 Q146 56 146 86 Z" fill="#b45309"/>
+      <rect x="94" y="76" width="52" height="8" fill="#78350f"/>`,
+  philosopher: `
+      <circle cx="168" cy="96" r="4" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+      <circle cx="178" cy="82" r="6" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+      <circle cx="192" cy="62" r="10" fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>`,
+  scholar: `
+      <polygon points="120,56 170,74 120,92 70,74" fill="#1e3a8a"/>
+      <circle cx="120" cy="74" r="4" fill="#facc15"/>
+      <path d="M120 74 Q150 80 156 100" stroke="#facc15" stroke-width="3" fill="none"/>
+      <circle cx="156" cy="104" r="5" fill="#facc15"/>`,
+  empath: `
+      <path d="M164 66 c4 -7 14 -5 14 3 c0 6 -8 11 -14 15 c-6 -4 -14 -9 -14 -15 c0 -8 10 -10 14 -3 Z" fill="#f43f5e"/>
+      <path d="M190 96 c2.5 -4.5 9 -3 9 2 c0 4 -5 7 -9 9.5 c-4 -2.5 -9 -5.5 -9 -9.5 c0 -5 6.5 -6.5 9 -2 Z" fill="#fb7185"/>`,
+  strategist: `
+      <rect x="113" y="142" width="14" height="8" rx="2" fill="#065f46"/>
+      <polygon points="120,150 110,158 120,170 130,158" fill="#047857"/>`,
+  dreamer: `
+      <path d="M86 86 Q114 46 166 54 Q150 72 152 86 Z" fill="#7c3aed"/>
+      <circle cx="168" cy="53" r="8" fill="#ffffff"/>
+      <path d="M66 96 l2 4.6 4.6 2 -4.6 2 -2 4.6 -2 -4.6 -4.6 -2 4.6 -2 Z" fill="#c4b5fd"/>
+      <path d="M186 104 l2 4.6 4.6 2 -4.6 2 -2 4.6 -2 -4.6 -4.6 -2 4.6 -2 Z" fill="#c4b5fd"/>`,
+  detective: `
+      <ellipse cx="120" cy="86" rx="45" ry="9" fill="#4338ca"/>
+      <path d="M82 86 Q120 44 158 86 Z" fill="#4f46e5"/>
+      <circle cx="180" cy="142" r="14" fill="#ffffff" fill-opacity="0.35" stroke="#1f2937" stroke-width="4"/>
+      <line x1="190" y1="152" x2="202" y2="166" stroke="#1f2937" stroke-width="6" stroke-linecap="round"/>`,
+  healer: `
+      <path d="M120 86 Q120 72 120 64" stroke="#059669" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <path d="M120 66 Q104 60 98 44 Q116 44 120 60 Z" fill="#34d399"/>
+      <path d="M120 66 Q136 60 142 44 Q124 44 120 60 Z" fill="#6ee7b7"/>`,
+  challenger: `
+      <path d="M76 104 Q120 88 164 104 L164 116 Q120 100 76 116 Z" fill="#b91c1c"/>
+      <circle cx="164" cy="110" r="5" fill="#991b1b"/>
+      <polygon points="168,110 190,100 184,116" fill="#b91c1c"/>
+      <polygon points="168,112 188,124 178,128" fill="#dc2626"/>`,
+  curator: `
+      <path d="M84 84 Q86 56 120 54 Q154 56 156 84 Q120 70 84 84 Z" fill="#db2777"/>
+      <circle cx="120" cy="52" r="4" fill="#9d174d"/>`,
+  timetraveler: `
+      <path d="M150 96 Q166 100 174 92" stroke="#a16207" stroke-width="3" stroke-dasharray="1 5" stroke-linecap="round" fill="none"/>
+      <rect x="172" y="58" width="10" height="7" rx="2" fill="#a16207"/>
+      <circle cx="177" cy="80" r="16" fill="#fef08a" stroke="#a16207" stroke-width="4"/>
+      <line x1="177" y1="80" x2="177" y2="70" stroke="#a16207" stroke-width="3" stroke-linecap="round"/>
+      <line x1="177" y1="80" x2="184" y2="84" stroke="#a16207" stroke-width="3" stroke-linecap="round"/>`,
+  innovator: `
+      <line x1="120" y1="90" x2="120" y2="64" stroke="#0e7490" stroke-width="4"/>
+      <circle cx="120" cy="54" r="10" fill="#fde047" stroke="#a16207" stroke-width="3"/>
+      <line x1="102" y1="44" x2="108" y2="50" stroke="#facc15" stroke-width="3" stroke-linecap="round"/>
+      <line x1="138" y1="44" x2="132" y2="50" stroke="#facc15" stroke-width="3" stroke-linecap="round"/>
+      <line x1="120" y1="36" x2="120" y2="42" stroke="#facc15" stroke-width="3" stroke-linecap="round"/>`,
+  wanderer: `
+      <polygon points="158,82 198,64 178,94" fill="#ffffff" stroke="#475569" stroke-width="3" stroke-linejoin="round"/>
+      <polygon points="174,84 178,94 172,98" fill="#cbd5e1" stroke="#475569" stroke-width="2" stroke-linejoin="round"/>`,
+}
+
+/**
+ * キャラクターSVG文字列を生成する
+ */
+export const personalityCharacterSvg = (
+  type: PersonalityType,
+  size = 240
+): string => {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 240 240">
+      <circle cx="120" cy="120" r="112" fill="${type.colorLight}"/>
+      <ellipse cx="120" cy="138" rx="63" ry="60" fill="${type.color}"/>
+      <ellipse cx="120" cy="162" rx="42" ry="30" fill="#ffffff" opacity="0.3"/>
+      ${face(type)}
+      <path d="M120 196 C104 186 84 186 72 192 L72 170 C84 164 104 164 120 174 Z" fill="#fffdf7" stroke="#8b5e34" stroke-width="4" stroke-linejoin="round"/>
+      <path d="M120 196 C136 186 156 186 168 192 L168 170 C156 164 136 164 120 174 Z" fill="#fffdf7" stroke="#8b5e34" stroke-width="4" stroke-linejoin="round"/>
+      <line x1="120" y1="174" x2="120" y2="196" stroke="#8b5e34" stroke-width="3"/>
+      <circle cx="74" cy="178" r="9" fill="${type.color}"/>
+      <circle cx="166" cy="178" r="9" fill="${type.color}"/>
+      ${accessories[type.id] ?? ''}
+    </svg>`
+    .replace(/\n\s*/g, ' ')
+    .trim()
+}
+
+/**
+ * Web UIの<img>で使えるdata URIを生成する
+ */
+export const personalityCharacterDataUri = (
+  type: PersonalityType,
+  size = 240
+): string =>
+  `data:image/svg+xml;utf8,${encodeURIComponent(personalityCharacterSvg(type, size))}`

--- a/apps/web/src/libs/ai/personality/personality-types.test.ts
+++ b/apps/web/src/libs/ai/personality/personality-types.test.ts
@@ -1,0 +1,82 @@
+import {
+  PERSONALITY_TYPES,
+  PERSONALITY_TYPE_IDS,
+  findPersonalityType,
+  personalityTypePromptList,
+} from './personality-types'
+import {
+  personalityCharacterSvg,
+  personalityCharacterDataUri,
+} from './personality-character'
+
+describe('PERSONALITY_TYPES', () => {
+  it('idが重複していないこと', () => {
+    expect(new Set(PERSONALITY_TYPE_IDS).size).toBe(PERSONALITY_TYPES.length)
+  })
+
+  it('全タイプに必須フィールドが定義されていること', () => {
+    for (const type of PERSONALITY_TYPES) {
+      expect(type.id).toMatch(/^[a-z]+$/)
+      expect(type.code).toMatch(/^[A-Z]+$/)
+      expect(type.name).not.toBe('')
+      expect(type.tagline).not.toBe('')
+      expect(type.criteria).not.toBe('')
+      expect(type.color).toMatch(/^#[0-9a-f]{6}$/)
+      expect(type.colorLight).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+})
+
+describe('findPersonalityType()', () => {
+  it('idからタイプを取得できること', () => {
+    expect(findPersonalityType('adventurer')?.name).toBe('物語の冒険家')
+  })
+
+  it('未知のid・空文字・未設定はundefinedを返すこと', () => {
+    expect(findPersonalityType('unknown_type')).toBeUndefined()
+    expect(findPersonalityType('')).toBeUndefined()
+    expect(findPersonalityType(undefined)).toBeUndefined()
+    expect(findPersonalityType(null)).toBeUndefined()
+  })
+})
+
+describe('personalityTypePromptList', () => {
+  it('全タイプのidと名前が含まれていること', () => {
+    for (const type of PERSONALITY_TYPES) {
+      expect(personalityTypePromptList).toContain(type.id)
+      expect(personalityTypePromptList).toContain(type.name)
+    }
+  })
+})
+
+describe('personalityCharacterSvg()', () => {
+  it('全タイプでSVGが生成できること', () => {
+    for (const type of PERSONALITY_TYPES) {
+      const svg = personalityCharacterSvg(type)
+      expect(svg).toContain('<svg')
+      expect(svg).toContain(type.color)
+      expect(svg).toContain(type.colorLight)
+    }
+  })
+
+  it('OG画像でbase64エンコードできるようASCII文字のみで構成されていること', () => {
+    for (const type of PERSONALITY_TYPES) {
+      const svg = personalityCharacterSvg(type)
+      // eslint-disable-next-line no-control-regex
+      expect(svg).toMatch(/^[\x00-\x7F]*$/)
+    }
+  })
+
+  it('サイズを指定できること', () => {
+    const svg = personalityCharacterSvg(PERSONALITY_TYPES[0], 300)
+    expect(svg).toContain('width="300"')
+    expect(svg).toContain('height="300"')
+  })
+})
+
+describe('personalityCharacterDataUri()', () => {
+  it('data URI形式で返ること', () => {
+    const uri = personalityCharacterDataUri(PERSONALITY_TYPES[0])
+    expect(uri).toMatch(/^data:image\/svg\+xml;utf8,/)
+  })
+})

--- a/apps/web/src/libs/ai/personality/personality-types.ts
+++ b/apps/web/src/libs/ai/personality/personality-types.ts
@@ -1,0 +1,178 @@
+/**
+ * AI読書性格診断のタイプ定義（MBTI風）
+ *
+ * LLMが読書履歴から1タイプを分類し、タイプごとのキャラクター画像を表示する。
+ * idはプロンプト・保存データ・キャラクターSVGで共通のキーとして使用する。
+ */
+export type PersonalityFace = 'round' | 'closed' | 'sparkle'
+
+export type PersonalityType = {
+  /** 保存データ・プロンプトで使う識別子 */
+  id: string
+  /** MBTIのタイプコード風の英字コード */
+  code: string
+  /** タイプ名（日本語） */
+  name: string
+  /** タイプの短い説明（診断カードに表示） */
+  tagline: string
+  /** LLM分類用の判定基準 */
+  criteria: string
+  /** キャラクターのメインカラー */
+  color: string
+  /** 背景・アクセント用のライトカラー */
+  colorLight: string
+  /** キャラクターの表情 */
+  face: PersonalityFace
+}
+
+export const PERSONALITY_TYPES: PersonalityType[] = [
+  {
+    id: 'adventurer',
+    code: 'ADVENTURER',
+    name: '物語の冒険家',
+    tagline: 'ページをめくるたび、新しい世界へ飛び込む',
+    criteria: '小説・ファンタジー・冒険譚を中心に、物語世界への没入を楽しむ',
+    color: '#f59e0b',
+    colorLight: '#fef3c7',
+    face: 'round',
+  },
+  {
+    id: 'philosopher',
+    code: 'PHILOSOPHER',
+    name: '静かな思索家',
+    tagline: '一冊の問いを、どこまでも深く掘り下げる',
+    criteria: '哲学・思想・抽象的なテーマを好み、深く考えながら読む',
+    color: '#8b5cf6',
+    colorLight: '#ede9fe',
+    face: 'closed',
+  },
+  {
+    id: 'scholar',
+    code: 'SCHOLAR',
+    name: '知の探究者',
+    tagline: '知識を積み上げ、世界の解像度を上げていく',
+    criteria: 'ノンフィクション・専門書・学術書で体系的な知識を求める',
+    color: '#3b82f6',
+    colorLight: '#dbeafe',
+    face: 'round',
+  },
+  {
+    id: 'empath',
+    code: 'EMPATH',
+    name: '共感の語り部',
+    tagline: '登場人物の心に寄り添い、涙も笑いも共にする',
+    criteria:
+      '人間ドラマ・恋愛・家族の物語に感情移入し、感想に感情が豊かに表れる',
+    color: '#ec4899',
+    colorLight: '#fce7f3',
+    face: 'round',
+  },
+  {
+    id: 'strategist',
+    code: 'STRATEGIST',
+    name: '未来の戦略家',
+    tagline: '読んだ知識を、明日の一手に変える',
+    criteria: 'ビジネス・自己啓発・実用書から行動につながる学びを得る',
+    color: '#10b981',
+    colorLight: '#d1fae5',
+    face: 'round',
+  },
+  {
+    id: 'dreamer',
+    code: 'DREAMER',
+    name: '夢見る空想家',
+    tagline: '現実の少し外側に、お気に入りの居場所がある',
+    criteria: 'SF・ファンタジー・幻想的な物語で想像力を羽ばたかせる',
+    color: '#a78bfa',
+    colorLight: '#f3e8ff',
+    face: 'sparkle',
+  },
+  {
+    id: 'detective',
+    code: 'DETECTIVE',
+    name: '真相を追う探偵',
+    tagline: '伏線とどんでん返しに、心を奪われる',
+    criteria: 'ミステリー・サスペンス・謎解きを好み、構造や伏線に注目する',
+    color: '#6366f1',
+    colorLight: '#e0e7ff',
+    face: 'round',
+  },
+  {
+    id: 'healer',
+    code: 'HEALER',
+    name: '心を整える癒し人',
+    tagline: '本のページは、深呼吸のための場所',
+    criteria: 'エッセイ・詩・穏やかな物語で心を癒やし、読書で気持ちを整える',
+    color: '#34d399',
+    colorLight: '#ecfdf5',
+    face: 'closed',
+  },
+  {
+    id: 'challenger',
+    code: 'CHALLENGER',
+    name: '限界を超える挑戦者',
+    tagline: '難しい本ほど、燃える',
+    criteria:
+      '難解な本・大作・幅広いジャンルに果敢に挑み、読破すること自体を楽しむ',
+    color: '#ef4444',
+    colorLight: '#fee2e2',
+    face: 'round',
+  },
+  {
+    id: 'curator',
+    code: 'CURATOR',
+    name: '美を愛でる審美家',
+    tagline: '言葉の手ざわりと、装丁の美しさに敏感',
+    criteria: '芸術・デザイン・文体の美しい作品を好み、表現そのものを味わう',
+    color: '#f472b6',
+    colorLight: '#fdf2f8',
+    face: 'sparkle',
+  },
+  {
+    id: 'timetraveler',
+    code: 'TIMETRAVELER',
+    name: '時を渡る旅人',
+    tagline: '歴史の中に、今を生きるヒントを探す',
+    criteria: '歴史・伝記・古典を通じて過去と対話し、時代を越えた学びを得る',
+    color: '#eab308',
+    colorLight: '#fef9c3',
+    face: 'round',
+  },
+  {
+    id: 'innovator',
+    code: 'INNOVATOR',
+    name: 'ひらめきの発明家',
+    tagline: '本と本のあいだで、アイデアが火花を散らす',
+    criteria:
+      '科学・テクノロジー・新しい概念に惹かれ、知識を組み合わせて発想する',
+    color: '#06b6d4',
+    colorLight: '#cffafe',
+    face: 'sparkle',
+  },
+  {
+    id: 'wanderer',
+    code: 'WANDERER',
+    name: '気ままな漂流者',
+    tagline: 'ジャンルの海を、風の向くまま漂う',
+    criteria: '特定ジャンルに縛られず、そのときの気分と偶然の出会いで本を選ぶ',
+    color: '#64748b',
+    colorLight: '#f1f5f9',
+    face: 'closed',
+  },
+]
+
+export const PERSONALITY_TYPE_IDS = PERSONALITY_TYPES.map((t) => t.id)
+
+/**
+ * idからタイプ定義を取得する（未知のid・未設定はundefined）
+ */
+export const findPersonalityType = (
+  id: string | undefined | null
+): PersonalityType | undefined => PERSONALITY_TYPES.find((t) => t.id === id)
+
+/**
+ * プロンプトに埋め込むタイプ一覧（id: 名前 - 判定基準）
+ */
+export const personalityTypePromptList = PERSONALITY_TYPES.map(
+  (t) => `  - ${t.id}（${t.name}）: ${t.criteria}`
+).join('\n')

--- a/apps/web/src/libs/ai/prompt.ts
+++ b/apps/web/src/libs/ai/prompt.ts
@@ -1,12 +1,16 @@
+import { personalityTypePromptList } from './personality/personality-types'
+
 export const aiSummaryPrompt = `以下のJSONを読み取り、ルールに基づきフィードバックを提供してください。
 [ルール]
-・フィードバックは「一言でいうとこんな人」「読書傾向分析」「感情分析」「無意識に追いかけているもの」「総評」の5項目
+・フィードバックは「読書性格タイプ」「一言でいうとこんな人」「読書傾向分析」「感情分析」「無意識に追いかけているもの」「総評」の6項目
 ・各分析の本文は「ユーザーは」や「あなたは」などは出力せず、本題から入ること
 ・感想の引用はせず、あなたの言葉で書いてください
 ・できるだけ抽象的な表現は避け、極論を言う事
 ・character_summaryは最大50文字、それ以外のvalueはそれぞれ最大400文字までとする
-・出力はjsonでキー名はそれぞれcharacter_summary, reading_trend_analysis, sentiment_analysis, hidden_theme_discovery, overall_feedbackで、valueは日本語で出力
-・分析に必要なデータが十分ではない場合、各valueは「分析に必要なデータが足りません」とする
+・出力はjsonでキー名はこの順にpersonality_type, character_summary, reading_trend_analysis, sentiment_analysis, hidden_theme_discovery, overall_feedbackで、valueは日本語で出力
+・分析に必要なデータが十分ではない場合、personality_type以外の各valueは「分析に必要なデータが足りません」とする
+・読書性格タイプ：読書傾向を総合的に分析し、以下の12タイプから最も当てはまるものを1つ選ぶ。personality_typeのvalueは必ず以下のID（英小文字）のみを出力すること。データが足りない場合は空文字にする
+${personalityTypePromptList}
 ・一言でいうとこんな人：4つの指標を総合的に分析し、このユーザーの人物像を一言で表現する。キャッチーで印象的な見出しにすること
 ・読書傾向分析：ユーザーが好むジャンル、著者、テーマを分析し、その傾向を可視化する
 ・感情分析：ユーザーが読んだ本の感想を分析して、どんな本が最もポジティブな反応を引き出したか、または特定の感情を呼び起こしたかを示す

--- a/apps/web/src/pages/api/ai-summary/_create.ts
+++ b/apps/web/src/pages/api/ai-summary/_create.ts
@@ -1,6 +1,7 @@
 import prisma from '@/libs/prisma/edge'
 import dayjs from 'dayjs'
 import { aiSummaryPrompt } from '@/libs/ai/prompt'
+import { PERSONALITY_TYPE_IDS } from '@/libs/ai/personality/personality-types'
 import openai from '@/libs/ai/openai'
 import { RequestCookies } from '@edge-runtime/cookies'
 
@@ -77,6 +78,7 @@ export const handleCreate = async (req: Request) => {
         console.log(text)
         const json = JSON.parse(text)
         const {
+          personality_type,
           character_summary,
           reading_trend_analysis,
           sentiment_analysis,
@@ -88,7 +90,11 @@ export const handleCreate = async (req: Request) => {
             userId,
             sheetId: sheet.id,
             analysis: {
-              _schemaVersion: 2,
+              _schemaVersion: 3,
+              // 定義外のタイプIDが返ってきた場合は未診断扱いにする
+              personality_type: PERSONALITY_TYPE_IDS.includes(personality_type)
+                ? personality_type
+                : '',
               character_summary,
               reading_trend_analysis,
               sentiment_analysis,

--- a/apps/web/src/pages/api/og.tsx
+++ b/apps/web/src/pages/api/og.tsx
@@ -1,4 +1,6 @@
 import { ImageResponse } from '@vercel/og'
+import { findPersonalityType } from '@/libs/ai/personality/personality-types'
+import { personalityCharacterSvg } from '@/libs/ai/personality/personality-character'
 
 export const config = {
   runtime: 'edge',
@@ -52,6 +54,76 @@ const renderAi = (params: URLSearchParams) => {
   const user = trim(params.get('user') ?? 'kidoku user', 24)
   const summary = trim(params.get('summary') ?? 'あなたの読書性格', 60)
   const sub = trim(params.get('sub') ?? '', 90)
+  // MBTI風の読書性格タイプ（キャラクター画像付きレイアウト）
+  const personalityType = findPersonalityType(params.get('ptype'))
+
+  if (personalityType) {
+    // SVGはASCIIのみで構成されているためbtoaでbase64化できる
+    const characterSrc = `data:image/svg+xml;base64,${btoa(
+      personalityCharacterSvg(personalityType)
+    )}`
+    return new ImageResponse(
+      <div
+        style={{
+          ...baseStyle,
+          background: `linear-gradient(135deg, ${personalityType.colorLight} 0%, rgba(255,255,255,1) 55%, ${personalityType.colorLight} 100%)`,
+        }}
+      >
+        {header('AI読書性格診断', personalityType.color)}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '40px' }}>
+          <div
+            style={{
+              ...cardStyle,
+              flex: 1,
+              gap: '16px',
+            }}
+          >
+            <div style={{ fontSize: 26, color: '#475569' }}>
+              {`${user} さんの読書性格タイプは…`}
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                alignSelf: 'flex-start',
+                borderRadius: '9999px',
+                backgroundColor: personalityType.color,
+                color: '#ffffff',
+                fontSize: 24,
+                fontWeight: 700,
+                letterSpacing: '0.2em',
+                padding: '6px 20px',
+              }}
+            >
+              {personalityType.code}
+            </div>
+            <div
+              style={{
+                fontSize: 64,
+                fontWeight: 800,
+                lineHeight: 1.15,
+                color: personalityType.color,
+              }}
+            >
+              {personalityType.name}
+            </div>
+            {summary ? (
+              <div style={{ fontSize: 30, color: '#334155', lineHeight: 1.4 }}>
+                {`「${summary}」`}
+              </div>
+            ) : null}
+            {sub ? (
+              <div style={{ fontSize: 24, color: '#64748b', lineHeight: 1.4 }}>
+                {sub}
+              </div>
+            ) : null}
+          </div>
+          <img src={characterSrc} width={300} height={300} />
+        </div>
+        {footer('#475569')}
+      </div>,
+      { width, height }
+    )
+  }
 
   return new ImageResponse(
     <div


### PR DESCRIPTION
- 12種類の読書性格タイプ（物語の冒険家・真相を追う探偵など）を定義し、LLMが読書履歴から1タイプを分類するようプロンプトを拡張
- タイプごとの固有キャラクターをSVGで生成し、診断結果のヒーローカードにタイプコード・タイプ名とともに表示
- OG共有画像（/api/og?type=ai）にもキャラクターとタイプ名を反映
- 分析スキーマをv3にバンプし、既存データはpersonality_type空文字で読み取り時マイグレーション（キャラクターなしの従来表示にフォールバック）
- 手動ペースト保存（GraphQL saveAiSummary）は旧フォーマットも引き続き受け付ける

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014rB7fUm4HLaLcwFegXFQdC