### PR TITLE
Show saved book data immediately after edit without waiting for ISR

### DIFF
--- a/apps/web/src/features/books/components/BookPage.tsx
+++ b/apps/web/src/features/books/components/BookPage.tsx
@@ -73,6 +73,14 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
     router.back()
   }
 
+  // 保存成功時: 編集結果を即座に表示へ反映して読み取りモードに戻す。
+  // ISRのpropsは非同期に再生成されるため、それを待つと保存直後に古い内容が
+  // 表示されてしまう。保存済みデータでローカル状態を更新して即時反映する。
+  const handleSaved = (updatedBook: Book) => {
+    setBook(updatedBook)
+    setEditMode(false)
+  }
+
   const handleEditToggle = async () => {
     // 編集モードに入る際は、マスクされていない最新のメモを取得してから切り替える。
     // ISR直後の再取得が完了する前に編集ボタンを押すと、マスク済みメモ(*****)が
@@ -158,6 +166,7 @@ export default function BookPage({ book: initialBook }: BookPageProps) {
             book={book}
             onClose={handleClose}
             onCancel={handleEditToggle}
+            onSaved={handleSaved}
           />
         ) : (
           <BookDetailReadModal

--- a/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailEditPage.tsx
@@ -13,12 +13,14 @@ interface Props {
   book: Book
   onClose: () => void
   onCancel: () => void
+  onSaved: (book: Book) => void
 }
 
 export const BookDetailEditPage: React.FC<Props> = ({
   book: initialBook,
   onClose,
   onCancel,
+  onSaved,
 }) => {
   const [book, setBook] = useState<Book>(initialBook)
   const [loading, setLoading] = useState(false)
@@ -99,13 +101,21 @@ export const BookDetailEditPage: React.FC<Props> = ({
       })
 
       if (response.ok) {
+        // サーバー側で画像がVercel Blobにアップロードされた場合、最終的なURLが返る
+        const result = await response.json().catch(() => null)
+        const savedBook: Book =
+          result?.image != null ? { ...book, image: result.image } : book
+
         // 保存成功時にローカルストレージの下書きを削除
         if (book.id) {
           removeBookDraft(String(book.id))
         }
         reward() // 保存成功時にアニメーション
         setTimeout(() => {
-          onCancel() // 編集モードを終了して読み取りモードに戻る
+          // 編集内容を親に反映して読み取りモードに戻る。
+          // ISRの再生成を待たずに保存済みデータを即座に表示するため、
+          // 再取得ではなく手元の編集結果をそのまま渡す。
+          onSaved(savedBook)
         }, 500) // アニメーションが見えるように少し遅延
       }
     } catch (error) {


### PR DESCRIPTION
## 概要

書籍編集後、ISR（Incremental Static Regeneration）の再生成を待たずに、保存済みデータをすぐに画面に反映するように改善しました。

従来は編集完了後に `onCancel()` を呼び出して読み取りモードに戻るだけでしたが、サーバーから返された最新データ（特に画像URL）を親コンポーネントに渡すことで、ISR再生成の完了を待たずに即座に編集結果を表示できるようになります。

### 変更内容

1. **BookDetailEditPage.tsx**
   - Props に `onSaved: (book: Book) => void` コールバックを追加
   - 保存成功時にサーバーレスポンスから最新の書籍データを取得
   - Vercel Blob にアップロードされた画像の最終URLをレスポンスから抽出
   - `onCancel()` の代わりに `onSaved(savedBook)` を呼び出し

2. **BookPage.tsx**
   - `handleSaved()` メソッドを追加：受け取った書籍データでローカル状態を更新し、編集モードを終了
   - `BookDetailEditPage` に `onSaved={handleSaved}` を渡す

## 変更の種類

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Other

## チェックリスト

- [ ] `pnpm validate` が通ること
- [ ] Prisma スキーマ変更時: Web/API 両方を更新した
- [ ] GraphQL 変更時: `pnpm --filter web codegen` を実行した
- [ ] 必要に応じてテストを追加・更新した

## テスト計画

既存の機能フローに対する変更のため、以下の動作確認で十分です：
- 書籍編集後、保存ボタンをクリック → 編集結果が即座に読み取りモードに反映されることを確認
- 画像を含む編集の場合、Vercel Blob にアップロードされた最新URLが表示されることを確認

https://claude.ai/code/session_01YJE4oCQKRvfywArVooRaT9