### PR TITLE
自分のページでAI分析結果を最新取得する

### DIFF
--- a/apps/web/src/features/sheet/components/AiSummaries/AiSummaries.tsx
+++ b/apps/web/src/features/sheet/components/AiSummaries/AiSummaries.tsx
@@ -44,7 +44,8 @@ export const AiSummaries: React.FC<Props> = ({
     setOpen,
     summaryIndex,
     setSummaryIndex,
-  } = useAiHelpers(sheet, aiSummaries)
+    summaries,
+  } = useAiHelpers(sheet, aiSummaries, isMine)
 
   // MBTI風の読書性格タイプ（未診断の過去データ・不明IDはundefined）
   const personalityType = findPersonalityType(json?.personality_type)
@@ -190,17 +191,17 @@ export const AiSummaries: React.FC<Props> = ({
             <span className="shrink text-left">
               ※読書履歴(カテゴリ、公開中のメモ)に基づきAIが生成しています。
             </span>
-            {aiSummaries.length > 1 && (
+            {summaries.length > 1 && (
               <StepIndicator
                 step={summaryIndex}
-                maxStep={aiSummaries.length}
+                maxStep={summaries.length}
                 onBack={() => {
                   if (summaryIndex === 0) return
                   setSummaryIndex(summaryIndex - 1)
                 }}
                 onNext={() => {
                   const newSummaryIndex = summaryIndex + 1
-                  if (newSummaryIndex === aiSummaries.length) return
+                  if (newSummaryIndex === summaries.length) return
                   setSummaryIndex(newSummaryIndex)
                 }}
               />

--- a/apps/web/src/features/sheet/components/AiSummaries/useAiHelpers.ts
+++ b/apps/web/src/features/sheet/components/AiSummaries/useAiHelpers.ts
@@ -3,12 +3,18 @@ import { toggleNoScrollBody } from '@/utils/element'
 import { useSession } from 'next-auth/react'
 import { useMutation } from '@apollo/client'
 import { deleteAiSummaryMutation } from '../../api'
+import type { AiSummariesJson } from './types'
 
-const useAiHelpers = (sheet, aiSummaries) => {
+const useAiHelpers = (
+  sheet: string,
+  aiSummaries: AiSummariesJson[],
+  isMine: boolean
+) => {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [json, setJson] = useState(null)
+  const [summaries, setSummaries] = useState(aiSummaries)
   const [error, setError] = useState(null)
   const [summaryIndex, setSummaryIndex] = useState(0)
   const { data: session } = useSession()
@@ -19,8 +25,38 @@ const useAiHelpers = (sheet, aiSummaries) => {
   }, [sheet])
 
   useEffect(() => {
-    setJson(aiSummaries[summaryIndex])
-  }, [sheet, summaryIndex])
+    setSummaries(aiSummaries)
+  }, [aiSummaries])
+
+  useEffect(() => {
+    setJson(summaries[summaryIndex] ?? null)
+  }, [summaries, summaryIndex])
+
+  useEffect(() => {
+    if (!isMine) return
+
+    const controller = new AbortController()
+    const fetchSummaries = async () => {
+      try {
+        const response = await fetch(
+          `/api/ai-summary?sheetName=${encodeURIComponent(sheet)}`,
+          { signal: controller.signal }
+        )
+        if (!response.ok) return
+        const { summaries } = await response.json()
+        if (!controller.signal.aborted) {
+          setSummaries(summaries)
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          console.error('AI分析結果の取得に失敗しました', error)
+        }
+      }
+    }
+
+    fetchSummaries()
+    return () => controller.abort()
+  }, [isMine, sheet])
 
   const generateSummary = async (sheetName, months, categories) => {
     if (loading || !session) return
@@ -72,7 +108,8 @@ const useAiHelpers = (sheet, aiSummaries) => {
       })
       if (data?.deleteAiSummary) {
         // 削除したアイテムをリストから除外
-        const newSummaries = aiSummaries.filter((s) => s.id !== id)
+        const newSummaries = summaries.filter((s) => s.id !== id)
+        setSummaries(newSummaries)
         if (newSummaries.length === 0) {
           setJson(null)
         } else {
@@ -103,6 +140,7 @@ const useAiHelpers = (sheet, aiSummaries) => {
     setOpen,
     summaryIndex,
     setSummaryIndex,
+    summaries,
   }
 }
 

--- a/apps/web/src/pages/api/ai-summary/_get.ts
+++ b/apps/web/src/pages/api/ai-summary/_get.ts
@@ -1,0 +1,44 @@
+import { migrateAnalysis } from '@/features/sheet/components/AiSummaries/migrator'
+import prisma from '@/libs/prisma/edge'
+import { RequestCookies } from '@edge-runtime/cookies'
+
+export const handleGet = async (req: Request) => {
+  const cookies = new RequestCookies(req.headers)
+  const sessionToken = cookies.get('next-auth.session-token')?.value
+  const sheetName = new URL(req.url).searchParams.get('sheetName')
+
+  if (!sessionToken || !sheetName) {
+    return new Response(JSON.stringify({ result: false }), { status: 400 })
+  }
+
+  const session = await prisma.session.findFirst({
+    where: { sessionToken },
+    select: { userId: true },
+  })
+  if (!session) {
+    return new Response(JSON.stringify({ result: false }), { status: 401 })
+  }
+
+  const sheet = await prisma.sheets.findFirst({
+    where: { userId: session.userId, name: sheetName },
+    select: { id: true },
+  })
+  if (!sheet) {
+    return new Response(JSON.stringify({ result: false }), { status: 404 })
+  }
+
+  const summaries = await prisma.aiSummaries.findMany({
+    where: { userId: session.userId, sheetId: sheet.id },
+    select: { id: true, analysis: true },
+    orderBy: { created: 'desc' },
+  })
+
+  return Response.json({
+    summaries: summaries.map(({ id, analysis }) => ({
+      id,
+      ...migrateAnalysis(
+        typeof analysis === 'string' ? JSON.parse(analysis) : analysis
+      ),
+    })),
+  })
+}

--- a/apps/web/src/pages/api/ai-summary/index.ts
+++ b/apps/web/src/pages/api/ai-summary/index.ts
@@ -1,4 +1,5 @@
 import { handleCreate } from './_create'
+import { handleGet } from './_get'
 
 export const config = {
   runtime: 'edge',
@@ -6,6 +7,8 @@ export const config = {
 
 export default async (req: Request) => {
   switch (req.method) {
+    case 'GET':
+      return handleGet(req)
     case 'POST':
       return handleCreate(req)
     default:


### PR DESCRIPTION
### Motivation
- ISRで配信された古いページを読み込んだ直後に、保存済みのAI分析結果が見えなくなる事象を防ぐために、本人ページではクライアント側で最新の分析結果を取得する必要があった。 
- 分析結果のスキーマは過去バージョンが混在するため、返す際に最新スキーマへマイグレーションしたい。 
- 削除やページングの表示状態とサーバ側の実データの不整合を防ぎたい。 

### Description
- 認証済みユーザー自身のシートに限定して保存済み分析を返すGET APIを `apps/web/src/pages/api/ai-summary/_get.ts` に追加し、セッション検証・シート所有チェックを行った上で分析を取得して `migrateAnalysis` で最新スキーマに変換して返す実装を追加した。 
- `apps/web/src/pages/api/ai-summary/index.ts` を更新して `GET` を新しいハンドラにルーティングするようにした。 
- クライアント側のヘルパーを拡張して `useAiHelpers(sheet, aiSummaries, isMine)` とし、`isMine` の場合に `GET /api/ai-summary?sheetName=...` で最新一覧をフェッチしてローカルの `summaries` 状態を更新する機能を `apps/web/src/features/sheet/components/AiSummaries/useAiHelpers.ts` に追加した。 
- 表示コンポーネント側 `apps/web/src/features/sheet/components/AiSummaries/AiSummaries.tsx` では `isMine` を渡してローカル `summaries` を使うように変更し、ページングや削除後の表示不整合を解消した。 

### Testing
- 型チェックは `pnpm --filter web check-types` を実行して成功した（`tsc --noEmit`）。 
- リントは `pnpm --filter web lint` を実行してエラーは無く警告が7件出ているがビルドに影響はなかった。 
- フォーマット検査は `pnpm --filter web exec prettier --check src/pages/api/ai-summary/_get.ts src/pages/api/ai-summary/index.ts src/features/sheet/components/AiSummaries/AiSummaries.tsx src/features/sheet/components/AiSummaries/useAiHelpers.ts` を実行して問題なかった。 
- `git diff --check` 相当の確認で差分に問題は見つからなかった。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a632700ef5c832e8523a35b8bfe9e60)