### PR TITLE
「発見」に過去の今日の読書記録コーナーを追加

### DIFF
--- a/apps/web/src/features/social/components/DiscoverPage.tsx
+++ b/apps/web/src/features/social/components/DiscoverPage.tsx
@@ -14,6 +14,7 @@ import {
   feedQuery,
 } from '../api'
 import { LikeButton } from './LikeButton'
+import { OnThisDaySection } from './OnThisDaySection'
 
 interface PopularBook {
   id: string
@@ -79,6 +80,8 @@ export const DiscoverPage: React.FC = () => {
       />
 
       <h1 className="mb-8 mt-6 text-center text-2xl font-bold">発見</h1>
+
+      <OnThisDaySection />
 
       {isAuthed && feed.length > 0 && (
         <section className="mb-12">

--- a/apps/web/src/features/social/components/OnThisDaySection.tsx
+++ b/apps/web/src/features/social/components/OnThisDaySection.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import useSWR from 'swr'
+import { TitleWithLine } from '@/components/label/TitleWithLine'
+import { useCachedSession } from '@/hooks/useCachedSession'
+import { NO_IMAGE } from '@/libs/constants'
+
+interface OnThisDayBook {
+  id: number
+  title: string
+  author: string
+  image: string
+  yearsAgo: number
+}
+
+const fetcher = (url: string) =>
+  fetch(url).then((response) => {
+    if (!response.ok) throw new Error('failed')
+    return response.json()
+  })
+
+/** ログインユーザーが過去の同じ日に読み終えた本を振り返るコーナー。 */
+export const OnThisDaySection: React.FC = () => {
+  const { session, status } = useCachedSession()
+  const { data } = useSWR<{ books: OnThisDayBook[] }>(
+    status === 'authenticated' && session ? '/api/me/on-this-day' : null,
+    fetcher
+  )
+
+  const books = data?.books ?? []
+  if (books.length === 0) return null
+
+  return (
+    <section className="mb-12">
+      <TitleWithLine text="〇〇年前の今日、これ読みました" className="mb-4" />
+      <div className="flex gap-4 overflow-x-auto pb-3">
+        {books.map((book) => (
+          <Link
+            key={book.id}
+            href={`/books/${book.id}`}
+            className="flex w-72 min-w-72 items-center gap-4 rounded-xl border border-teal-100 bg-teal-50/50 p-4 transition hover:border-teal-200 hover:bg-teal-50"
+          >
+            <img
+              src={book.image || NO_IMAGE}
+              alt={book.title}
+              className="h-28 w-20 shrink-0 rounded object-cover shadow-sm"
+            />
+            <div className="min-w-0">
+              <p className="text-xs font-bold text-teal-700">
+                {book.yearsAgo}年前の今日
+              </p>
+              <h3 className="mt-1 line-clamp-2 text-sm font-bold text-gray-800">
+                {book.title}
+              </h3>
+              {book.author && (
+                <p className="mt-1 truncate text-xs text-gray-500">
+                  {book.author}
+                </p>
+              )}
+              <p className="mt-3 text-xs text-teal-700">読書記録を見る →</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
### Motivation
- ユーザーが「発見」ページで過去の同じ日に自分が読み終えた本を振り返れるコーナーを追加するため。

### Description
- 新しいコンポーネントを追加して`apps/web/src/features/social/components/OnThisDaySection.tsx`に実装し、ログインユーザー向けに`/api/me/on-this-day`から取得した本を横スクロールカードで表示するようにしました。 
- `apps/web/src/features/social/components/DiscoverPage.tsx`に`OnThisDaySection`を組み込み、該当レコードがないか未ログイン時はコーナーを非表示にする`null`返却のガードを導入しました。 
- 表示カードは年数・タイトル・著者・書影を含み、書影は未登録時に`NO_IMAGE`へフォールバックする仕様にし、見た目は既存のTailwindユーティリティで整えています。 

### Testing
- `pnpm --filter web lint`を実行してエラーは発生せず（既存の警告7件のみ）。
- `pnpm --filter web check-types`を実行して型チェックに成功しました。 
- `pnpm --filter web test --runInBand`を実行して単体テストは「10スイート / 85テスト 全て通過」しました。 
- Playwrightベースの画面確認で`/discover`をレンダリングしてスクリーンショット(`/tmp/kidoku/screenshots/discover-on-this-day.png`)を取得し、表示を目視確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e85bb42d8832e9d0bfb5f5dde4435)