### PR TITLE
fix: ホームヒーローの上下余白を縮小

### DIFF
--- a/apps/web/src/features/index/components/IndexPage.tsx
+++ b/apps/web/src/features/index/components/IndexPage.tsx
@@ -33,7 +33,7 @@ export const IndexPage: React.FC<Props> = ({ comments }) => {
     <>
       {/* ヒーロー：淡々と記録する、を伝えるミニマルなファーストビュー */}
       <section className="border-b border-gray-100">
-        <Container className="px-4 py-20 sm:py-28">
+        <Container className="px-4 py-10 sm:py-16">
           <div className="mx-auto max-w-xl text-center">
             <h1 className="text-2xl font-bold leading-relaxed tracking-wide text-gray-800 sm:text-3xl">
               読んだ本を、ただ記録する。


### PR DESCRIPTION
### Motivation
- ホーム画面のヒーロー（「記録をはじめる」）セクションが上下に余白が大きく、ファーストビューが間延びして見えるためコンパクトにしたい。 

### Description
- `apps/web/src/features/index/components/IndexPage.tsx` の `Container` クラスを `px-4 py-20 sm:py-28` から `px-4 py-10 sm:py-16` に変更して縦の余白を縮小した。 

### Testing
- `pnpm --filter web lint` を実行しエラーはなく警告が表示される状態で成功した。 
- `pnpm --filter web check-types` を実行して型チェックは成功した。 
- Playwright によるスクリーンショット取得は実行環境のブラウザ依存ライブラリ不足および開発サーバー応答の問題で取得できなかったが、変更はスタイルのみのため影響範囲は限定的である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77bf783a68832e9731abcec1e7fac3)