### PR TITLE
fix: 非公開の本へのコメントを禁止する

### DIFF
--- a/apps/api/src/application/usecases/book-comments/create-book-comment.spec.ts
+++ b/apps/api/src/application/usecases/book-comments/create-book-comment.spec.ts
@@ -10,6 +10,7 @@ describe('CreateBookCommentUseCase', () => {
 
   beforeEach(() => {
     mockRepo = {
+      isBookPublic: jest.fn().mockResolvedValue(true),
       create: jest.fn(),
       findByBook: jest.fn(),
       delete: jest.fn(),
@@ -73,6 +74,25 @@ describe('CreateBookCommentUseCase', () => {
   it('不正な内容はドメインバリデーションで弾かれる', async () => {
     await expect(useCase.execute('commenter', 10, '   ')).rejects.toThrow(
       'コメントを入力してください',
+    );
+    expect(mockRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('非公開の書籍にはコメントを作成しない', async () => {
+    mockRepo.isBookPublic.mockResolvedValue(false);
+
+    await expect(useCase.execute('commenter', 10, 'いいね')).rejects.toThrow(
+      '非公開の書籍にはコメントできません',
+    );
+    expect(mockRepo.create).not.toHaveBeenCalled();
+    expect(mockNotificationRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('存在しない書籍にはコメントを作成しない', async () => {
+    mockRepo.isBookPublic.mockResolvedValue(null);
+
+    await expect(useCase.execute('commenter', 10, 'いいね')).rejects.toThrow(
+      '書籍が見つかりません',
     );
     expect(mockRepo.create).not.toHaveBeenCalled();
   });

--- a/apps/api/src/application/usecases/book-comments/create-book-comment.ts
+++ b/apps/api/src/application/usecases/book-comments/create-book-comment.ts
@@ -16,6 +16,14 @@ export class CreateBookCommentUseCase {
     content: string,
   ): Promise<BookComment> {
     const comment = BookComment.create({ userId, bookId, content });
+    const isBookPublic = await this.bookCommentRepository.isBookPublic(bookId);
+    if (isBookPublic === null) {
+      throw new Error('書籍が見つかりません');
+    }
+    if (!isBookPublic) {
+      throw new Error('非公開の書籍にはコメントできません');
+    }
+
     const { comment: created, bookOwnerId } =
       await this.bookCommentRepository.create(comment);
 

--- a/apps/api/src/domain/repositories/book-comment.ts
+++ b/apps/api/src/domain/repositories/book-comment.ts
@@ -2,6 +2,9 @@ import { BookComment } from '../models/book-comment';
 import { PaginatedResult } from '../types/paginated-result';
 
 export abstract class IBookCommentRepository {
+  /** 指定した本がコメント可能な公開状態かを返す。存在しない場合は null */
+  abstract isBookPublic(bookId: number): Promise<boolean | null>;
+
   /** コメントを作成し、作成されたコメントと本の所有者IDを返す */
   abstract create(
     comment: BookComment,

--- a/apps/api/src/infrastructure/repositories/book-comment.ts
+++ b/apps/api/src/infrastructure/repositories/book-comment.ts
@@ -8,15 +8,27 @@ import { PaginatedResult } from '../../domain/types/paginated-result';
 export class BookCommentRepository implements IBookCommentRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async isBookPublic(bookId: number): Promise<boolean | null> {
+    const book = await this.prisma.books.findUnique({
+      where: { id: bookId },
+      select: { isPublicMemo: true },
+    });
+    return book?.isPublicMemo ?? null;
+  }
+
   async create(
     comment: BookComment,
   ): Promise<{ comment: BookComment; bookOwnerId: string | null }> {
     const book = await this.prisma.books.findUnique({
       where: { id: comment.bookId },
-      select: { userId: true },
+      select: { userId: true, isPublicMemo: true },
     });
     if (!book) {
       throw new Error('書籍が見つかりません');
+    }
+    // 公開状態が事前確認後に変更された場合にも、コメントを保存しない。
+    if (!book.isPublicMemo) {
+      throw new Error('非公開の書籍にはコメントできません');
     }
 
     const created = await this.prisma.bookComment.create({

--- a/apps/web/src/features/books/components/CommentSection.tsx
+++ b/apps/web/src/features/books/components/CommentSection.tsx
@@ -27,11 +27,16 @@ interface Props {
   bookId: number | string
   /** 本の所有者ID。投稿者本人に加えて本の所有者もコメントを削除できる */
   bookOwnerId?: string
+  canComment?: boolean
 }
 
 const MAX_LENGTH = 1000
 
-export const CommentSection: React.FC<Props> = ({ bookId, bookOwnerId }) => {
+export const CommentSection: React.FC<Props> = ({
+  bookId,
+  bookOwnerId,
+  canComment = true,
+}) => {
   const numericBookId = Number(bookId)
   const { session, status } = useCachedSession()
   const isAuthed = status === 'authenticated'
@@ -98,42 +103,50 @@ export const CommentSection: React.FC<Props> = ({ bookId, bookOwnerId }) => {
       </h2>
 
       {/* 投稿フォーム */}
-      <form onSubmit={handleSubmit} className="mb-6">
-        <textarea
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          maxLength={MAX_LENGTH}
-          rows={3}
-          placeholder={
-            isAuthed
-              ? 'この感想にコメントする'
-              : 'ログインするとコメントできます'
-          }
-          onFocusCapture={() => {
-            if (!isAuthed) setOpenLogin(true)
-          }}
-          className="w-full resize-none rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
-        />
-        <div className="mt-2 flex items-center justify-between">
-          <span className="text-xs text-gray-400">
-            {content.length}/{MAX_LENGTH}
-          </span>
-          <button
-            type="submit"
-            disabled={submitting || content.trim().length === 0}
-            className="rounded-full bg-slate-800 px-5 py-2 text-sm font-bold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {submitting ? '送信中...' : 'コメントする'}
-          </button>
-        </div>
-      </form>
+      {canComment ? (
+        <form onSubmit={handleSubmit} className="mb-6">
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            maxLength={MAX_LENGTH}
+            rows={3}
+            placeholder={
+              isAuthed
+                ? 'この感想にコメントする'
+                : 'ログインするとコメントできます'
+            }
+            onFocusCapture={() => {
+              if (!isAuthed) setOpenLogin(true)
+            }}
+            className="w-full resize-none rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-xs text-gray-400">
+              {content.length}/{MAX_LENGTH}
+            </span>
+            <button
+              type="submit"
+              disabled={submitting || content.trim().length === 0}
+              className="rounded-full bg-slate-800 px-5 py-2 text-sm font-bold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {submitting ? '送信中...' : 'コメントする'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <p className="mb-6 rounded-lg bg-gray-100 p-4 text-center text-sm text-gray-500">
+          非公開の本にはコメントできません
+        </p>
+      )}
 
       {/* コメント一覧 */}
       {loading && comments.length === 0 ? (
         <p className="py-6 text-center text-sm text-gray-400">読み込み中...</p>
       ) : comments.length === 0 ? (
         <p className="py-6 text-center text-sm text-gray-400">
-          まだコメントはありません。最初のコメントを投稿してみましょう。
+          {canComment
+            ? 'まだコメントはありません。最初のコメントを投稿してみましょう。'
+            : 'コメントはありません。'}
         </p>
       ) : (
         <ul className="space-y-4">

--- a/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
+++ b/apps/web/src/features/sheet/components/BookDetailReadModal.tsx
@@ -289,7 +289,11 @@ export const BookDetailReadModal: React.FC<Props> = ({
         </div>
 
         {showComments && (
-          <CommentSection bookId={book.id} bookOwnerId={book.user?.id} />
+          <CommentSection
+            bookId={book.id}
+            bookOwnerId={book.user?.id}
+            canComment={book.isPublicMemo}
+          />
         )}
       </div>
 


### PR DESCRIPTION
### Motivation
- 非公開の本に他ユーザーがコメントできないようにサーバー側で確実に拒否するための処置を追加しました。 
- 存在しない書籍へのコメント試行を早期に検出して明確なエラーを返すことで不整合を防ぎます。

### Description
- `IBookCommentRepository` に `isBookPublic(bookId): Promise<boolean | null>` を追加し、`BookCommentRepository` に実装を追加して `isPublicMemo` を返すようにしました。 
- `CreateBookCommentUseCase.execute` 内で `isBookPublic` を呼んで存在チェックと公開状態チェックを行い、存在しない場合は `書籍が見つかりません`、非公開の場合は `非公開の書籍にはコメントできません` を投げて処理を中断するようにしました。 
- リポジトリ層の `create` でも公開状態を再確認して、事前確認後に非公開へ変更されていた場合に保存しない防御を追加しました。 
- フロントエンドの `CommentSection` に `canComment` プロパティを追加して非公開時は投稿フォームの代わりに案内文を表示するようにし、`BookDetailReadModal` で `book.isPublicMemo` を渡すようにしました。 
- 非公開・未存在の書籍に関するユニットテストを `apps/api/src/application/usecases/book-comments/create-book-comment.spec.ts` に追加しました。 

### Testing
- `pnpm --filter api test -- --runInBand application/usecases/book-comments/create-book-comment.spec.ts` を実行し、対象スペックは `5 passed` で成功しました。 
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter api exec prisma generate` を実行し、その後 `pnpm --filter api check-types` と `pnpm --filter web check-types` を実行して型チェックを通過しました。 
- `pnpm --filter api lint` と `pnpm --filter web lint` を実行しエラーは出ておらず警告のみ確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77ef19bff0832e99b0b5d9fc8fd004)